### PR TITLE
[FEAT] #20 Gallery List Component 구현

### DIFF
--- a/app/src/main/java/com/haman/allformemory/MainActivity.kt
+++ b/app/src/main/java/com/haman/allformemory/MainActivity.kt
@@ -6,11 +6,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.LaunchedEffect
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.feature.post.PostScreen
 import dagger.hilt.android.AndroidEntryPoint
 
+@OptIn(ExperimentalMaterialApi::class)
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val requestPermissionLauncher =

--- a/core/data/src/main/java/com/core/data/image/datastore/ImageDataStoreRepositoryImpl.kt
+++ b/core/data/src/main/java/com/core/data/image/datastore/ImageDataStoreRepositoryImpl.kt
@@ -17,7 +17,7 @@ class ImageDataStoreRepositoryImpl @Inject constructor(
             config = PagingConfig(
                 pageSize = ImageDataStorePagingSource.PAGING_SIZE,
                 enablePlaceholders = true,
-                maxSize = ImageDataStorePagingSource.PAGING_SIZE * 5
+//                maxSize = ImageDataStorePagingSource.PAGING_SIZE * 10
             ),
             pagingSourceFactory = {
                 ImageDataStorePagingSource(imageDatastore)

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Button.kt
@@ -2,7 +2,6 @@ package com.core.designsystem.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
@@ -17,6 +16,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.core.designsystem.modifiers.noRippleClickable
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.core.designsystem.theme.HarooTheme
 
@@ -38,7 +38,7 @@ fun HarooButton(
     content: @Composable RowScope.() -> Unit
 ) {
     HarooSurface(
-        modifier = modifier.clickable(
+        modifier = modifier.noRippleClickable(
             enabled = enabled,
             role = Role.Button,
             onClick = onClick

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Chip.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Chip.kt
@@ -2,7 +2,6 @@ package com.core.designsystem.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideTextStyle
@@ -16,6 +15,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.core.designsystem.modifiers.noRippleClickable
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.core.designsystem.theme.HarooTheme
 
@@ -34,7 +34,7 @@ fun HarooChip(
     HarooSurface(
         modifier = modifier.then(
             onClick?.let {
-                Modifier.clickable(
+                Modifier.noRippleClickable(
                     role = Role.Button,
                     onClick = it
                 )

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
@@ -4,7 +4,6 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -25,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import coil.compose.AsyncImage
 import com.core.designsystem.R
+import com.core.designsystem.modifiers.noRippleClickable
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.ImageUiModel
@@ -86,7 +86,7 @@ fun SelectableImage(
 ) {
     Box(
         modifier = modifier
-            .clickable(
+            .noRippleClickable(
                 role = Role.Button,
                 onClick = { onClick(image) },
                 enabled = enableSelectFlag || selectedIndex >= 0

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
@@ -5,10 +5,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.ImageBitmap
@@ -80,6 +81,7 @@ fun SelectableImage(
     modifier: Modifier = Modifier,
     image: ImageUiModel,
     shape: Shape = MaterialTheme.shapes.medium,
+    borderWidth: Dp = 1.dp,
     selectedIndex: Int,
     enableSelectFlag: Boolean = false,
     onClick: (ImageUiModel) -> Unit
@@ -93,7 +95,7 @@ fun SelectableImage(
             )
             .then(
                 if (selectedIndex >= 0) Modifier.border(
-                    3.dp,
+                    borderWidth,
                     HarooTheme.colors.brand,
                     shape = shape
                 ) else Modifier
@@ -108,15 +110,11 @@ fun SelectableImage(
                 color = HarooTheme.colors.dim,
                 alpha = 0.5f
             ) {
-                HarooChip(
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .padding(12.dp),
-                    backgroundColor = HarooTheme.colors.brand,
-                    alpha = 1f
-                ) {
-                    Text(text = "${selectedIndex + 1}")
-                }
+                Icon(
+                    imageVector = Icons.Rounded.CheckCircle,
+                    contentDescription = "select",
+                    tint = HarooTheme.colors.brand
+                )
             }
         } else if (enableSelectFlag.not()) {
             HarooSurface(

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
@@ -82,7 +83,8 @@ fun SelectableImage(
     image: ImageUiModel,
     shape: Shape = MaterialTheme.shapes.medium,
     borderWidth: Dp = 1.dp,
-    selectedIndex: Int,
+    selectedColor: Color = HarooTheme.colors.brand,
+    isSelected: Boolean,
     enableSelectFlag: Boolean = false,
     onClick: (ImageUiModel) -> Unit
 ) {
@@ -91,17 +93,15 @@ fun SelectableImage(
             .noRippleClickable(
                 role = Role.Button,
                 onClick = { onClick(image) },
-                enabled = enableSelectFlag || selectedIndex >= 0
+                enabled = enableSelectFlag || isSelected
             )
             .then(
-                if (selectedIndex >= 0) Modifier.border(
-                    borderWidth,
-                    HarooTheme.colors.brand,
-                    shape = shape
+                if (isSelected) Modifier.border(
+                    borderWidth, selectedColor, shape = shape
                 ) else Modifier
             )
     ) {
-        if (selectedIndex >= 0) {
+        if (isSelected) {
             HarooSurface(
                 modifier = Modifier
                     .fillMaxSize()
@@ -113,7 +113,7 @@ fun SelectableImage(
                 Icon(
                     imageVector = Icons.Rounded.CheckCircle,
                     contentDescription = "select",
-                    tint = HarooTheme.colors.brand
+                    tint = selectedColor
                 )
             }
         } else if (enableSelectFlag.not()) {

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Surface.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Surface.kt
@@ -11,10 +11,10 @@ import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
@@ -32,6 +32,7 @@ fun HarooSurface(
     shape: Shape = MaterialTheme.shapes.medium, // 모양
     color: Color = HarooTheme.colors.uiBackground, // 배경색
     contentColor: Color = HarooTheme.colors.text, // 내용 색
+    contentAlignment: Alignment = Alignment.Center,
     border: BorderStroke? = null, // 테두리 모양
     elevation: Dp = 0.dp, // 그림자 크기
     alpha: Float = 0.15f, // 배경 투명도
@@ -47,7 +48,8 @@ fun HarooSurface(
             )
             .then(if (border != null) Modifier.border(border, shape) else Modifier)
             .background(color.copy(alpha = alpha), shape)
-            .clip(shape)
+            .clip(shape),
+        contentAlignment = contentAlignment
     ) {
         CompositionLocalProvider(
             LocalContentColor provides contentColor,

--- a/core/designsystem/src/main/java/com/core/designsystem/modifiers/Ripple.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/modifiers/Ripple.kt
@@ -1,0 +1,22 @@
+package com.core.designsystem.modifiers
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.semantics.Role
+
+internal fun Modifier.noRippleClickable(
+    enabled: Boolean = true,
+    role: Role? = null,
+    onClick: () -> Unit
+): Modifier = composed {
+    clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = null,
+        enabled = enabled,
+        role = role,
+        onClick = onClick
+    )
+}

--- a/core/designsystem/src/main/java/com/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/theme/Color.kt
@@ -7,3 +7,5 @@ val DeepBlue800 = Color(0xFF0A104D)
 val DeepBlue900 = Color(0xFF000536)
 val Black = Color(0xFF000000)
 val White = Color(0xFFFFFFFF)
+
+val Dim = Color(0x80000000)

--- a/core/designsystem/src/main/java/com/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/theme/Theme.kt
@@ -68,7 +68,7 @@ class HarooColors(
     interactiveBackground: List<Color> = gradient4_1,
     text: Color,
     iconPrimary: Color = brand,
-    dim: Color = Black,
+    dim: Color = Dim,
     isDark: Boolean
 ) {
     var gradient4_1 by mutableStateOf(gradient4_1)

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import com.core.designsystem.components.BackAndRightButtonHeader
@@ -34,6 +35,7 @@ fun DrawerGalleryContainer(
     images: LazyPagingItems<ImageUiModel>,
     selectedImages: List<ImageUiModel>,
     limit: Int,
+    space: Dp = 0.dp,
     onClose: () -> Unit,
     onImageSelect: (List<ImageUiModel>) -> Unit
 ) {
@@ -49,6 +51,7 @@ fun DrawerGalleryContainer(
         images = images,
         selectedImages = tempSelectedImages.value,
         limit = limit,
+        space = space,
         onClose = onClose,
         onSelectFinish = { onImageSelect(tempSelectedImages.value) },
         onImageSelect = { image ->
@@ -66,6 +69,7 @@ fun GalleryContainer(
     images: LazyPagingItems<ImageUiModel>, // gallery image 정보
     selectedImages: List<ImageUiModel>, // 선택된 이미지 정보
     limit: Int = 0, // 선택할 수 이미지 최대 개수
+    space: Dp = 0.dp, // 각 이미지 사이 space
     onClose: () -> Unit, // 닫기 버튼 클릭 event
     onSelectFinish: () -> Unit, // 선택 완료 버튼 클릭 event
     onImageSelect: (ImageUiModel) -> Unit = {} // 이미지 선택 event
@@ -86,9 +90,9 @@ fun GalleryContainer(
         )
         LazyVerticalGrid(
             columns = GridCells.Fixed(galleryColumn),
-            contentPadding = PaddingValues(1.dp),
-            horizontalArrangement = Arrangement.spacedBy(1.dp),
-            verticalArrangement = Arrangement.spacedBy(1.dp)
+            contentPadding = PaddingValues(space),
+            horizontalArrangement = Arrangement.spacedBy(space),
+            verticalArrangement = Arrangement.spacedBy(space)
         ) {
             items(count = images.itemCount) { index ->
                 images[index]?.let { image ->
@@ -96,6 +100,7 @@ fun GalleryContainer(
                         modifier = Modifier.aspectRatio(1f),
                         image = image,
                         shape = RectangleShape,
+                        borderWidth = 2.dp,
                         selectedIndex = selectedImages.indexOf(image),
                         enableSelectFlag = selectedImages.size < limit,
                         onClick = onImageSelect

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
@@ -7,8 +7,13 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material.BottomDrawerState
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.RectangleShape
@@ -20,6 +25,41 @@ import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.ImageUiModel
 
 private const val galleryColumn = 3
+
+
+@ExperimentalMaterialApi
+@Composable
+fun DrawerGalleryContainer(
+    drawerState: BottomDrawerState,
+    images: LazyPagingItems<ImageUiModel>,
+    selectedImages: List<ImageUiModel>,
+    limit: Int,
+    onClose: () -> Unit,
+    onImageSelect: (List<ImageUiModel>) -> Unit
+) {
+    val tempSelectedImages = remember(selectedImages) { mutableStateOf(selectedImages) }
+
+    LaunchedEffect(key1 = drawerState.isAnimationRunning) {
+        if (drawerState.isExpanded) {
+            tempSelectedImages.value = selectedImages
+        }
+    }
+
+    GalleryContainer(
+        images = images,
+        selectedImages = tempSelectedImages.value,
+        limit = limit,
+        onClose = onClose,
+        onSelectFinish = { onImageSelect(tempSelectedImages.value) },
+        onImageSelect = { image ->
+            if (image in tempSelectedImages.value) {
+                tempSelectedImages.value = tempSelectedImages.value.filterNot { image == it }
+            } else {
+                tempSelectedImages.value += image
+            }
+        }
+    )
+}
 
 @Composable
 fun GalleryContainer(
@@ -51,12 +91,12 @@ fun GalleryContainer(
             verticalArrangement = Arrangement.spacedBy(1.dp)
         ) {
             items(count = images.itemCount) { index ->
-                images[index]?.let {
+                images[index]?.let { image ->
                     SelectableImage(
                         modifier = Modifier.aspectRatio(1f),
-                        image = it,
+                        image = image,
                         shape = RectangleShape,
-                        selectedIndex = selectedImages.indexOf(it),
+                        selectedIndex = selectedImages.indexOf(image),
                         enableSelectFlag = selectedImages.size < limit,
                         onClick = onImageSelect
                     )

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
@@ -1,5 +1,10 @@
 package com.core.ui.gallery
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -20,7 +25,9 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
+import com.core.designsystem.components.AsyncImageList
 import com.core.designsystem.components.BackAndRightButtonHeader
+import com.core.designsystem.components.RemovableImage
 import com.core.designsystem.components.SelectableImage
 import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.ImageUiModel
@@ -53,6 +60,11 @@ fun DrawerGalleryContainer(
         limit = limit,
         space = space,
         onClose = onClose,
+        onRemoveImage = { image ->
+            if (image in tempSelectedImages.value) {
+                tempSelectedImages.value = tempSelectedImages.value.filterNot { image == it }
+            }
+        },
         onSelectFinish = { onImageSelect(tempSelectedImages.value) },
         onImageSelect = { image ->
             if (image in tempSelectedImages.value) {
@@ -71,6 +83,7 @@ fun GalleryContainer(
     limit: Int = 0, // 선택할 수 이미지 최대 개수
     space: Dp = 0.dp, // 각 이미지 사이 space
     onClose: () -> Unit, // 닫기 버튼 클릭 event
+    onRemoveImage: (ImageUiModel) -> Unit, // 선택된 이미지 제거 event
     onSelectFinish: () -> Unit, // 선택 완료 버튼 클릭 event
     onImageSelect: (ImageUiModel) -> Unit = {} // 이미지 선택 event
 ) {
@@ -88,7 +101,25 @@ fun GalleryContainer(
                 Text(text = "${selectedImages.size}개 선택")
             }
         )
-
+        AnimatedVisibility(
+            visible = selectedImages.isNotEmpty(),
+            enter = slideInVertically(
+                initialOffsetY = { fullHeight -> -fullHeight },
+                animationSpec = tween(durationMillis = 100, easing = LinearOutSlowInEasing)
+            ) + fadeIn()
+        ) {
+            AsyncImageList(
+                images = selectedImages,
+                imageCount = limit,
+                contentPadding = 4.dp,
+                content = {
+                    RemovableImage(
+                        image = it.image,
+                        onRemove = onRemoveImage
+                    )
+                }
+            )
+        }
         LazyVerticalGrid(
             columns = GridCells.Fixed(galleryColumn),
             contentPadding = PaddingValues(space),

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
@@ -26,6 +26,8 @@ fun GalleryContainer(
     images: LazyPagingItems<ImageUiModel>, // gallery image 정보
     selectedImages: List<ImageUiModel>, // 선택된 이미지 정보
     limit: Int = 0, // 선택할 수 이미지 최대 개수
+    onClose: () -> Unit, // 닫기 버튼 클릭 event
+    onSelectFinish: () -> Unit, // 선택 완료 버튼 클릭 event
     onImageSelect: (ImageUiModel) -> Unit = {} // 이미지 선택 event
 ) {
     Column(
@@ -36,8 +38,8 @@ fun GalleryContainer(
         BackAndRightButtonHeader(
             title = "갤러리",
             showButtonFlag = selectedImages.isNotEmpty(),
-            onBackPressed = { },
-            onClick = { },
+            onBackPressed = onClose,
+            onClick = onSelectFinish,
             content = {
                 Text(text = "${selectedImages.size}개 선택")
             }

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
@@ -88,6 +88,7 @@ fun GalleryContainer(
                 Text(text = "${selectedImages.size}개 선택")
             }
         )
+
         LazyVerticalGrid(
             columns = GridCells.Fixed(galleryColumn),
             contentPadding = PaddingValues(space),
@@ -101,7 +102,7 @@ fun GalleryContainer(
                         image = image,
                         shape = RectangleShape,
                         borderWidth = 2.dp,
-                        selectedIndex = selectedImages.indexOf(image),
+                        isSelected = image in selectedImages,
                         enableSelectFlag = selectedImages.size < limit,
                         onClick = onImageSelect
                     )

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
@@ -105,7 +105,7 @@ fun GalleryContainer(
             visible = selectedImages.isNotEmpty(),
             enter = slideInVertically(
                 initialOffsetY = { fullHeight -> -fullHeight },
-                animationSpec = tween(durationMillis = 100, easing = LinearOutSlowInEasing)
+                animationSpec = tween(durationMillis = 300, easing = LinearOutSlowInEasing)
             ) + fadeIn()
         ) {
             AsyncImageList(

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryListContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryListContainer.kt
@@ -56,7 +56,7 @@ fun GalleryListContainer(
                     SelectableImage(
                         modifier = Modifier.aspectRatio(1f),
                         image = it,
-                        selectedIndex = selectedImages.indexOf(it),
+                        isSelected = it in selectedImages,
                         enableSelectFlag = selectedImages.size < limit,
                         onClick = onImageSelect
                     )

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryListContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryListContainer.kt
@@ -25,6 +25,7 @@ fun GalleryListContainer(
     images: LazyPagingItems<ImageUiModel>,
     selectedImages: List<ImageUiModel>,
     limit: Int = 0,
+    onClickAddButton: () -> Unit = {},
     onImageSelect: (ImageUiModel) -> Unit = {}
 ) {
     Row(
@@ -34,7 +35,7 @@ fun GalleryListContainer(
             modifier = Modifier
                 .fillMaxHeight()
                 .aspectRatio(1f),
-            onClick = {},
+            onClick = onClickAddButton,
             shape = MaterialTheme.shapes.medium,
             backgroundColor = HarooTheme.colors.uiBackground,
             alpha = 0.1f,

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryListContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryListContainer.kt
@@ -1,0 +1,66 @@
+package com.core.ui.gallery
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddPhotoAlternate
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.items
+import com.core.designsystem.components.HarooButton
+import com.core.designsystem.components.SelectableImage
+import com.core.designsystem.theme.HarooTheme
+import com.core.model.feature.ImageUiModel
+
+@Composable
+fun GalleryListContainer(
+    modifier: Modifier = Modifier,
+    images: LazyPagingItems<ImageUiModel>,
+    selectedImages: List<ImageUiModel>,
+    limit: Int = 0,
+    onImageSelect: (ImageUiModel) -> Unit = {}
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        HarooButton(
+            modifier = Modifier
+                .fillMaxHeight()
+                .aspectRatio(1f),
+            onClick = {},
+            shape = MaterialTheme.shapes.medium,
+            backgroundColor = HarooTheme.colors.uiBackground,
+            alpha = 0.1f,
+            contentColor = HarooTheme.colors.text,
+            content = {
+                Icon(
+                    imageVector = Icons.Default.AddPhotoAlternate,
+                    contentDescription = "Add Photo"
+                )
+            }
+        )
+        LazyRow(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(items = images, key = { image -> image.id ?: image.hashCode() }) { image ->
+                image?.let {
+                    SelectableImage(
+                        modifier = Modifier.aspectRatio(1f),
+                        image = it,
+                        selectedIndex = selectedImages.indexOf(it),
+                        enableSelectFlag = selectedImages.size < limit,
+                        onClick = onImageSelect
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/post/build.gradle.kts
+++ b/feature/post/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":core:ui"))
     implementation(project(":core:model"))
+    implementation(project(":core:designsystem"))
 
     implementation(libs.paging.compose)
 }

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -1,5 +1,6 @@
 package com.feature.post
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,6 +32,12 @@ fun PostScreen(
     val coroutineScope = rememberCoroutineScope()
     val bottomDrawerState = rememberBottomDrawerState(initialValue = BottomDrawerValue.Closed)
 
+    BackHandler(enabled = bottomDrawerState.isOpen) {
+        coroutineScope.launch {
+            bottomDrawerState.close()
+        }
+    }
+
     BottomDrawer(
         drawerState = bottomDrawerState,
         drawerContent = {
@@ -45,6 +52,7 @@ fun PostScreen(
                 onImageSelect = postViewModel::selectImage
             )
         },
+        gesturesEnabled = false,
         scrimColor = HarooTheme.colors.dim
     ) {
         Column(

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -16,6 +17,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.core.designsystem.theme.HarooTheme
 import com.core.ui.gallery.GalleryContainer
 import com.core.ui.gallery.GalleryListContainer
+import kotlinx.coroutines.launch
 
 @ExperimentalMaterialApi
 @Composable
@@ -25,17 +27,25 @@ fun PostScreen(
     val images = postViewModel.images.collectAsLazyPagingItems()
     val selectedImages = postViewModel.selectedImages.collectAsState()
 
-    val modalSheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
-    ModalBottomSheetLayout(
-        sheetState = modalSheetState,
-        sheetContent = {
+//    val modalSheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
+    val coroutineScope = rememberCoroutineScope()
+    val bottomDrawerState = rememberBottomDrawerState(initialValue = BottomDrawerValue.Closed)
+
+    BottomDrawer(
+        drawerState = bottomDrawerState,
+        drawerContent = {
             GalleryContainer(
                 images = images,
                 selectedImages = selectedImages.value,
                 limit = PostViewModel.IMAGE_SELECT_LIMIT,
+                onClose = {
+                    coroutineScope.launch { bottomDrawerState.close() }
+                },
+                onSelectFinish = {},
                 onImageSelect = postViewModel::selectImage
             )
-        }
+        },
+        scrimColor = HarooTheme.colors.dim
     ) {
         Column(
             modifier = Modifier
@@ -54,6 +64,9 @@ fun PostScreen(
                     images = images,
                     selectedImages = selectedImages.value,
                     limit = PostViewModel.IMAGE_SELECT_LIMIT,
+                    onClickAddButton = {
+                        coroutineScope.launch { bottomDrawerState.expand() }
+                    },
                     onImageSelect = postViewModel::selectImage
                 )
             }

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -1,14 +1,21 @@
 package com.feature.post
 
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.core.designsystem.theme.HarooTheme
 import com.core.ui.gallery.GalleryContainer
+import com.core.ui.gallery.GalleryListContainer
 
 @ExperimentalMaterialApi
 @Composable
@@ -30,6 +37,26 @@ fun PostScreen(
             )
         }
     ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground))
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
 
+            }
+            BottomAppBar(
+                modifier = Modifier.padding(vertical = 12.dp),
+                backgroundColor = Color.Transparent
+            ) {
+                GalleryListContainer(
+                    modifier = Modifier,
+                    images = images,
+                    selectedImages = selectedImages.value,
+                    limit = PostViewModel.IMAGE_SELECT_LIMIT,
+                    onImageSelect = postViewModel::selectImage
+                )
+            }
+        }
     }
 }

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -17,7 +17,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.core.designsystem.theme.HarooTheme
 import com.core.ui.gallery.DrawerGalleryContainer
-import com.core.ui.gallery.GalleryContainer
 import com.core.ui.gallery.GalleryListContainer
 import kotlinx.coroutines.launch
 
@@ -47,6 +46,7 @@ fun PostScreen(
                 images = images,
                 selectedImages = selectedImages.value,
                 limit = PostViewModel.IMAGE_SELECT_LIMIT,
+                space = 2.dp,
                 onClose = {
                     coroutineScope.launch { bottomDrawerState.close() }
                 },

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -1,14 +1,16 @@
 package com.feature.post
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.core.ui.gallery.GalleryContainer
 
+@ExperimentalMaterialApi
 @Composable
 fun PostScreen(
     postViewModel: PostViewModel = hiltViewModel()
@@ -16,14 +18,18 @@ fun PostScreen(
     val images = postViewModel.images.collectAsLazyPagingItems()
     val selectedImages = postViewModel.selectedImages.collectAsState()
 
-    Column(
-        modifier = Modifier.fillMaxSize()
+    val modalSheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
+    ModalBottomSheetLayout(
+        sheetState = modalSheetState,
+        sheetContent = {
+            GalleryContainer(
+                images = images,
+                selectedImages = selectedImages.value,
+                limit = PostViewModel.IMAGE_SELECT_LIMIT,
+                onImageSelect = postViewModel::selectImage
+            )
+        }
     ) {
-        GalleryContainer(
-            images = images,
-            selectedImages = selectedImages.value,
-            limit = PostViewModel.IMAGE_SELECT_LIMIT,
-            onImageSelect = postViewModel::selectImage
-        )
+
     }
 }

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.core.designsystem.theme.HarooTheme
+import com.core.ui.gallery.DrawerGalleryContainer
 import com.core.ui.gallery.GalleryContainer
 import com.core.ui.gallery.GalleryListContainer
 import kotlinx.coroutines.launch
@@ -41,15 +42,18 @@ fun PostScreen(
     BottomDrawer(
         drawerState = bottomDrawerState,
         drawerContent = {
-            GalleryContainer(
+            DrawerGalleryContainer(
+                drawerState = bottomDrawerState,
                 images = images,
                 selectedImages = selectedImages.value,
                 limit = PostViewModel.IMAGE_SELECT_LIMIT,
                 onClose = {
                     coroutineScope.launch { bottomDrawerState.close() }
                 },
-                onSelectFinish = {},
-                onImageSelect = postViewModel::selectImage
+                onImageSelect = {
+                    postViewModel.setImages(it)
+                    coroutineScope.launch { bottomDrawerState.close() }
+                }
             )
         },
         gesturesEnabled = false,

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -35,6 +35,10 @@ class PostViewModel @Inject constructor(
         }
     }
 
+    fun setImages(selectedImages: List<ImageUiModel>) {
+        _selectedImages.value = selectedImages
+    }
+
     companion object {
         const val IMAGE_SELECT_LIMIT = 4
     }


### PR DESCRIPTION
### 📌 내용
Device로부터 이미지를 받아와 리스트 형태로 보여주며, 최대 4개의 이미지를 선택할 수 있는 Component 구현

### 🛠 Done
- [x] 리스트로 이미지를 보여주는 Component 구현
- [x] 최대 4개의 이미지만 선택할 수 있도록 처리
- [x] 갤러이 버튼 클릭 시, 이전에 만들어둔 Gallery Screen이 화면에 보이도록 구현

### 🪴 추가적인 구현사항
- Ripple 제거
```
// 공통적으로 사용할 수 있도록 Modifier로 빼두었습니다.
Modifier.noRippleClickable { }
```
- GalleryScreen에서 이미지를 쉽게 제거할 수 있도록 상단에 이미지 리스트 추가
- Image를 선택했을 때의 UI 변경
- GalleryScreen이 열린 상태에서 backbutton 클릭 시, drawer가 닫히도록 처리

### 🌹 UI
<img width="250" alt="스크린샷 2023-04-04 오후 10 02 36" src="https://user-images.githubusercontent.com/22411296/230601207-343a4e44-3f0b-4283-9ce3-7b609477c656.jpeg">

<img width="250" alt="스크린샷 2023-04-04 오후 10 02 36" src="https://user-images.githubusercontent.com/22411296/230601567-245469ab-8d62-454d-ad45-07a3e99e7bcf.jpeg">

### 🏠 관련 Issue
Closed #20 

