### PR TITLE
[FEAT] #23 태그 입력 & 리스트 Component

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.AllForMemory">
+            android:theme="@style/Theme.AllForMemory"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/haman/allformemory/MainActivity.kt
+++ b/app/src/main/java/com/haman/allformemory/MainActivity.kt
@@ -3,12 +3,12 @@ package com.haman.allformemory
 import android.Manifest
 import android.os.Build
 import android.os.Bundle
-import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.LaunchedEffect
+import androidx.core.view.WindowCompat
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.feature.post.PostScreen
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,6 +28,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
             AllForMemoryTheme {

--- a/app/src/main/java/com/haman/allformemory/MainActivity.kt
+++ b/app/src/main/java/com/haman/allformemory/MainActivity.kt
@@ -3,6 +3,7 @@ package com.haman.allformemory
 import android.Manifest
 import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -27,6 +28,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+
         setContent {
             AllForMemoryTheme {
                 LaunchedEffect(key1 = Unit) {

--- a/app/src/main/java/com/haman/allformemory/MainActivity.kt
+++ b/app/src/main/java/com/haman/allformemory/MainActivity.kt
@@ -6,14 +6,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.core.view.WindowCompat
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.feature.post.PostScreen
 import dagger.hilt.android.AndroidEntryPoint
 
-@OptIn(ExperimentalMaterialApi::class)
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val requestPermissionLauncher =

--- a/app/src/main/java/com/haman/allformemory/MainActivity.kt
+++ b/app/src/main/java/com/haman/allformemory/MainActivity.kt
@@ -29,8 +29,6 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-
         setContent {
             AllForMemoryTheme {
                 LaunchedEffect(key1 = Unit) {

--- a/app/src/main/java/com/haman/allformemory/MainActivity.kt
+++ b/app/src/main/java/com/haman/allformemory/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.core.view.WindowCompat
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.feature.post.PostScreen
@@ -24,6 +25,7 @@ class MainActivity : ComponentActivity() {
             }
         }
 
+    @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Button.kt
@@ -74,7 +74,7 @@ fun ButtonPreview() {
             HarooButton(
                 border = BorderStroke(
                     width = 1.dp,
-                    color = HarooTheme.colors.uiBackground
+                    color = HarooTheme.colors.uiBorder
                 ),
                 onClick = {},
                 alpha = 0f,

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Chip.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Chip.kt
@@ -26,7 +26,7 @@ fun HarooChip(
     shape: Shape = MaterialTheme.shapes.small,
     backgroundColor: Color = HarooTheme.colors.uiBackground,
     // 테두리 색
-    border: BorderStroke = BorderStroke(width = 1.dp, color = HarooTheme.colors.uiBorder),
+    border: BorderStroke? = BorderStroke(width = 1.dp, color = HarooTheme.colors.uiBorder),
     contentColor: Color = HarooTheme.colors.text,
     alpha: Float = 0f,
     content: @Composable RowScope.() -> Unit
@@ -46,7 +46,7 @@ fun HarooChip(
         border = border,
         contentColor = contentColor
     ) {
-        ProvideTextStyle(value = MaterialTheme.typography.body1) {
+        ProvideTextStyle(value = MaterialTheme.typography.body2) {
             Row(
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.Center,

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Chip.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Chip.kt
@@ -26,7 +26,7 @@ fun HarooChip(
     shape: Shape = MaterialTheme.shapes.small,
     backgroundColor: Color = HarooTheme.colors.uiBackground,
     // 테두리 색
-    border: BorderStroke = BorderStroke(width = 1.dp, color = backgroundColor),
+    border: BorderStroke = BorderStroke(width = 1.dp, color = HarooTheme.colors.uiBorder),
     contentColor: Color = HarooTheme.colors.text,
     alpha: Float = 0f,
     content: @Composable RowScope.() -> Unit

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Divider.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Divider.kt
@@ -1,0 +1,53 @@
+package com.core.designsystem.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.core.designsystem.theme.AllForMemoryTheme
+import com.core.designsystem.theme.HarooTheme
+
+@Composable
+fun HarooDivider(
+    modifier: Modifier = Modifier,
+    color: Color = HarooTheme.colors.uiBorder,
+    alpha: Float = 1f,
+    thickness: Dp = 1.dp,
+    startIndent: Dp = 0.dp // start offset
+) {
+    Divider(
+        modifier = modifier,
+        color = color.copy(alpha = alpha),
+        thickness = thickness,
+        startIndent = startIndent
+    )
+}
+
+@Composable
+@Preview(name = "basic divider")
+fun HarooDividerPreview() {
+    AllForMemoryTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(20.dp)
+                .background(
+                    Brush.linearGradient(HarooTheme.colors.gradient4_1)
+                )
+        ) {
+            HarooDivider(
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Drawer.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Drawer.kt
@@ -1,6 +1,7 @@
 package com.core.designsystem.components
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -19,9 +20,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import com.core.designsystem.theme.HarooTheme
 
-private fun <T> drawerAnimationSpec() = tween<T>(durationMillis = 250, easing = LinearEasing)
+private fun <T> drawerAnimationSpec() = tween<T>(durationMillis = 150, easing = LinearEasing)
 
 @Composable
 fun HarooBottomDrawer(
@@ -30,6 +32,8 @@ fun HarooBottomDrawer(
     drawerContent: @Composable () -> Unit,
     drawerShape: Shape = MaterialTheme.shapes.large,
     drawerElevation: Dp = DrawerDefaults.Elevation,
+    enter: FiniteAnimationSpec<IntOffset> = drawerAnimationSpec(),
+    exit: FiniteAnimationSpec<IntOffset> = drawerAnimationSpec(),
     scrimColor: Color = HarooTheme.colors.dim,
     scrimAlpha: Float = 0.5f,
     content: @Composable BoxScope.() -> Unit
@@ -53,11 +57,11 @@ fun HarooBottomDrawer(
             visible = drawerState.isShow.value,
             enter = slideInVertically(
                 initialOffsetY = { fullHeight -> fullHeight },
-                animationSpec = drawerAnimationSpec()
+                animationSpec = enter
             ),
             exit = slideOutVertically(
                 targetOffsetY = { fullHeight -> fullHeight },
-                animationSpec = drawerAnimationSpec()
+                animationSpec = exit
             ),
             content = {
                 HarooSurface(

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Drawer.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Drawer.kt
@@ -1,0 +1,92 @@
+package com.core.designsystem.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.DrawerDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import com.core.designsystem.theme.HarooTheme
+
+private fun <T> drawerAnimationSpec() = tween<T>(durationMillis = 250, easing = LinearEasing)
+
+@Composable
+fun HarooBottomDrawer(
+    modifier: Modifier = Modifier,
+    drawerState: HarooBottomDrawerState = rememberHarooBottomDrawerState(),
+    drawerContent: @Composable () -> Unit,
+    drawerShape: Shape = MaterialTheme.shapes.large,
+    drawerElevation: Dp = DrawerDefaults.Elevation,
+    scrimColor: Color = HarooTheme.colors.dim,
+    scrimAlpha: Float = 0.5f,
+    content: @Composable BoxScope.() -> Unit
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        content()
+        AnimatedVisibility(
+            modifier = Modifier.fillMaxSize(),
+            visible = drawerState.isShow.value,
+            enter = fadeIn(drawerAnimationSpec())
+        ) {
+            HarooSurface(
+                modifier = Modifier.fillMaxSize(),
+                color = scrimColor,
+                alpha = scrimAlpha,
+                content = {}
+            )
+        }
+        AnimatedVisibility(
+            modifier = Modifier.align(Alignment.BottomCenter),
+            visible = drawerState.isShow.value,
+            enter = slideInVertically(
+                initialOffsetY = { fullHeight -> fullHeight },
+                animationSpec = drawerAnimationSpec()
+            ),
+            exit = slideOutVertically(
+                targetOffsetY = { fullHeight -> fullHeight },
+                animationSpec = drawerAnimationSpec()
+            ),
+            content = {
+                HarooSurface(
+                    shape = drawerShape,
+                    elevation = drawerElevation,
+                    content = drawerContent
+                )
+            }
+        )
+    }
+}
+
+@Composable
+fun rememberHarooBottomDrawerState(
+    initialValue: Boolean = false
+) = remember(initialValue) {
+    HarooBottomDrawerState(initialValue)
+}
+
+class HarooBottomDrawerState(
+    initialValue: Boolean
+) {
+    val isShow = mutableStateOf(initialValue)
+
+    fun hide() {
+        isShow.value = false
+    }
+
+    fun show() {
+        isShow.value = true
+    }
+}

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Header.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Header.kt
@@ -45,7 +45,7 @@ fun BackAndRightButtonHeader(
                 HarooButton(
                     border = BorderStroke(
                         width = 1.dp,
-                        color = HarooTheme.colors.uiBackground
+                        color = HarooTheme.colors.uiBorder
                     ),
                     onClick = onClick,
                     alpha = 0f,

--- a/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
@@ -2,10 +2,7 @@ package com.core.designsystem.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActionScope
 import androidx.compose.foundation.text.KeyboardActions
@@ -61,6 +58,7 @@ fun HarooTextField(
     ) {
         BasicTextField(
             modifier = Modifier
+                .fillMaxWidth()
                 .focusRequester(focusRequester),
             textStyle = MaterialTheme.typography.body1.copy(
                 color = HarooTheme.colors.text

--- a/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActionScope
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
@@ -18,6 +21,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.core.designsystem.theme.HarooTheme
@@ -37,7 +41,8 @@ fun HarooTextField(
     placeHolder: String = "", // hint
     singleLine: Boolean = true, // 한줄 여부
     contentPadding: PaddingValues = PaddingValues(), // Surface 와 TextField padding
-    maxLines: Int = Int.MAX_VALUE // 최대 입력 가능 라인
+    maxLines: Int = Int.MAX_VALUE, // 최대 입력 가능 라인
+    onDone: KeyboardActionScope.() -> Unit = {}
 ) {
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(key1 = autoFocus) {
@@ -61,6 +66,10 @@ fun HarooTextField(
                 color = HarooTheme.colors.text
             ),
             value = value,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = onDone
+            ),
             onValueChange = onValueChange,
             readOnly = enabled.not(),
             singleLine = singleLine,
@@ -89,7 +98,8 @@ fun TextFieldPreview() {
             HarooTextField(
                 value = value,
                 onValueChange = { value = it },
-                placeHolder = "내용을 입력해주세요."
+                placeHolder = "내용을 입력해주세요.",
+                onDone = {}
             )
         }
     }

--- a/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
@@ -3,19 +3,20 @@ package com.core.designsystem.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.core.designsystem.theme.HarooTheme
 
@@ -31,17 +32,19 @@ fun HarooTextField(
     border: BorderStroke? = null, // 테두리 모양
     placeHolder: String = "", // hint
     singleLine: Boolean = true, // 한줄 여부
+    contentPadding: PaddingValues = PaddingValues(), // Surface 와 TextField padding
     maxLines: Int = Int.MAX_VALUE // 최대 입력 가능 라인
 ) {
     HarooSurface(
-        modifier = modifier,
+        modifier = modifier
+            .padding(contentPadding),
         shape = shape,
         color = color,
         contentColor = contentColor,
+        contentAlignment = Alignment.CenterStart,
         border = border
     ) {
         BasicTextField(
-            modifier = Modifier.padding(16.dp),
             textStyle = MaterialTheme.typography.body1,
             value = value,
             onValueChange = onValueChange,

--- a/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
@@ -12,6 +12,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -26,29 +28,41 @@ fun HarooTextField(
     enabled: Boolean = true, // 사용 가능 여부
     value: String, // 입력 값
     onValueChange: (String) -> Unit, // 입력값 변경
+    autoFocus: Boolean = false, // 자동 focus 여부
     shape: Shape = MaterialTheme.shapes.medium,
     color: Color = HarooTheme.colors.uiBackground, // 배경 색
     contentColor: Color = HarooTheme.colors.text, // 내부 색
+    alpha: Float = 0f,
     border: BorderStroke? = null, // 테두리 모양
     placeHolder: String = "", // hint
     singleLine: Boolean = true, // 한줄 여부
     contentPadding: PaddingValues = PaddingValues(), // Surface 와 TextField padding
     maxLines: Int = Int.MAX_VALUE // 최대 입력 가능 라인
 ) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(key1 = autoFocus) {
+        if (autoFocus) focusRequester.requestFocus()
+    }
+
     HarooSurface(
         modifier = modifier
             .padding(contentPadding),
         shape = shape,
         color = color,
+        alpha = alpha,
         contentColor = contentColor,
         contentAlignment = Alignment.CenterStart,
         border = border
     ) {
         BasicTextField(
-            textStyle = MaterialTheme.typography.body1,
+            modifier = Modifier
+                .focusRequester(focusRequester),
+            textStyle = MaterialTheme.typography.body1.copy(
+                color = HarooTheme.colors.text
+            ),
             value = value,
             onValueChange = onValueChange,
-            readOnly = enabled,
+            readOnly = enabled.not(),
             singleLine = singleLine,
             maxLines = maxLines,
             decorationBox = { innerTextField ->

--- a/core/designsystem/src/main/java/com/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/theme/Theme.kt
@@ -10,6 +10,7 @@ private val DarkColorScheme = HarooColors(
     gradient4_1 = listOf(PinkA400, DeepBlue900, Black, DeepBlue800),
     brand = PinkA400,
     uiBackground = White,
+    uiBorder = White,
     text = White,
     iconPrimary = White,
     isDark = true
@@ -19,6 +20,7 @@ private val LightColorScheme = HarooColors(
     gradient4_1 = listOf(PinkA400, DeepBlue900, Black, DeepBlue800),
     brand = PinkA400,
     uiBackground = White,
+    uiBorder = White,
     text = White,
     iconPrimary = White,
     isDark = false
@@ -65,6 +67,7 @@ class HarooColors(
     gradient4_1: List<Color>,
     brand: Color,
     uiBackground: Color,
+    uiBorder: Color,
     interactiveBackground: List<Color> = gradient4_1,
     text: Color,
     iconPrimary: Color = brand,
@@ -76,6 +79,8 @@ class HarooColors(
     var brand by mutableStateOf(brand)
         private set
     var uiBackground by mutableStateOf(uiBackground)
+        private set
+    var uiBorder by mutableStateOf(uiBorder)
         private set
     var interactiveBackground by mutableStateOf(interactiveBackground)
         private set
@@ -92,6 +97,7 @@ class HarooColors(
         this.gradient4_1 = other.gradient4_1
         this.brand = other.brand
         this.uiBackground = other.uiBackground
+        this.uiBorder = other.uiBorder
         this.interactiveBackground = other.interactiveBackground
         this.text = other.text
         this.iconPrimary = other.iconPrimary
@@ -103,6 +109,7 @@ class HarooColors(
         gradient4_1 = gradient4_1,
         brand = brand,
         uiBackground = uiBackground,
+        uiBorder = uiBorder,
         interactiveBackground = interactiveBackground,
         text = text,
         iconPrimary = iconPrimary,

--- a/core/model/src/main/java/com/core/model/feature/CellType.kt
+++ b/core/model/src/main/java/com/core/model/feature/CellType.kt
@@ -5,5 +5,6 @@ package com.core.model.feature
  */
 enum class CellType {
     POST,
-    IMAGE
+    IMAGE,
+    TAG
 }

--- a/core/model/src/main/java/com/core/model/feature/TagUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/TagUiModel.kt
@@ -1,0 +1,9 @@
+package com.core.model.feature
+
+/**
+ * tag 정보를 위한 ui model
+ */
+data class TagUiModel(
+    override val id: Long?,
+    val name: String
+) : Model(id, CellType.TAG)

--- a/core/model/src/main/java/com/core/model/feature/TagUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/TagUiModel.kt
@@ -4,6 +4,6 @@ package com.core.model.feature
  * tag 정보를 위한 ui model
  */
 data class TagUiModel(
-    override val id: Long?,
+    override val id: Long? = null,
     val name: String
 ) : Model(id, CellType.TAG)

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     implementation(project(":core:designsystem"))
 
     implementation(libs.paging.compose)
+    implementation(libs.accompanist.flowlayout)
 }

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -33,7 +32,6 @@ import com.core.model.feature.ImageUiModel
 private const val galleryColumn = 3
 
 
-@ExperimentalMaterialApi
 @Composable
 fun DrawerGalleryContainer(
     images: LazyPagingItems<ImageUiModel>,

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryContainer.kt
@@ -12,11 +12,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.material.BottomDrawerState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -38,7 +36,6 @@ private const val galleryColumn = 3
 @ExperimentalMaterialApi
 @Composable
 fun DrawerGalleryContainer(
-    drawerState: BottomDrawerState,
     images: LazyPagingItems<ImageUiModel>,
     selectedImages: List<ImageUiModel>,
     limit: Int,
@@ -47,12 +44,6 @@ fun DrawerGalleryContainer(
     onImageSelect: (List<ImageUiModel>) -> Unit
 ) {
     val tempSelectedImages = remember(selectedImages) { mutableStateOf(selectedImages) }
-
-    LaunchedEffect(key1 = drawerState.isAnimationRunning) {
-        if (drawerState.isExpanded) {
-            tempSelectedImages.value = selectedImages
-        }
-    }
 
     GalleryContainer(
         images = images,

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -1,4 +1,4 @@
-package com.core.ui
+package com.core.ui.post
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/main/java/com/core/ui/tag/Tag.kt
+++ b/core/ui/src/main/java/com/core/ui/tag/Tag.kt
@@ -1,0 +1,67 @@
+package com.core.ui.tag
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.core.designsystem.components.HarooButton
+import com.core.designsystem.components.HarooDivider
+import com.core.designsystem.components.HarooTextField
+import com.core.designsystem.theme.AllForMemoryTheme
+import com.core.model.feature.TagUiModel
+
+@Composable
+fun TagTextField(
+    modifier: Modifier = Modifier,
+    onAddTag: (TagUiModel) -> Unit
+) {
+    val tag = remember { mutableStateOf("") }
+
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            HarooTextField(
+                modifier = Modifier.weight(1f),
+                value = tag.value,
+                onValueChange = { tag.value = it },
+                color = Color.Transparent,
+                placeHolder = "태그 입력...",
+                contentPadding = PaddingValues(horizontal = 8.dp)
+            )
+            HarooButton(
+                alpha = 0f,
+                onClick = { onAddTag(TagUiModel(name = tag.value)) }
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Add,
+                    contentDescription = "Add Tag"
+                )
+            }
+        }
+        HarooDivider()
+    }
+}
+
+@Composable
+@Preview(name = "basic tag text field")
+fun TagTextFieldPreview() {
+    AllForMemoryTheme {
+        TagTextField(
+            onAddTag = {}
+        )
+    }
+}

--- a/core/ui/src/main/java/com/core/ui/tag/Tag.kt
+++ b/core/ui/src/main/java/com/core/ui/tag/Tag.kt
@@ -35,7 +35,8 @@ fun TagContainer(
     modifier: Modifier = Modifier,
     tags: List<TagUiModel>,
     tagSpace: Dp = 2.dp,
-    onAddTag: (TagUiModel) -> Unit
+    onAddTag: (String) -> Boolean,
+    onRemoveTag: (TagUiModel) -> Unit
 ) {
     val showTagTextField = remember { mutableStateOf(false) }
 
@@ -45,7 +46,9 @@ fun TagContainer(
             mainAxisSpacing = tagSpace,
             crossAxisSpacing = tagSpace
         ) {
-            tags.forEach { tag -> TagChip(name = tag.name, onClick = {}) }
+            tags.forEach { tag ->
+                TagChip(name = tag.name, onClick = { onRemoveTag(tag) })
+            }
             TagChip(
                 name = "+태그추가",
                 onClick = { showTagTextField.value = true }
@@ -59,8 +62,9 @@ fun TagContainer(
         ) {
             TagTextField(
                 onAddTag = {
-                    onAddTag(it)
-                    showTagTextField.value = false
+                    // tag 를 성공적으로 추가한 경우에만 태그 입력란 hide
+                    val isSuccess = onAddTag(it)
+                    if (isSuccess) showTagTextField.value = false
                 }
             )
         }
@@ -82,7 +86,7 @@ fun TagChip(
 @Composable
 fun TagTextField(
     modifier: Modifier = Modifier,
-    onAddTag: (TagUiModel) -> Unit
+    onAddTag: (String) -> Unit
 ) {
     val tag = remember { mutableStateOf("") }
 
@@ -102,7 +106,7 @@ fun TagTextField(
             )
             HarooButton(
                 alpha = 0f,
-                onClick = { onAddTag(TagUiModel(name = tag.value)) }
+                onClick = { onAddTag(tag.value) }
             ) {
                 Icon(
                     imageVector = Icons.Outlined.Add,
@@ -140,7 +144,8 @@ fun TagContainerPreview() {
                 TagUiModel(name = "test5"),
                 TagUiModel(name = "test6")
             ),
-            onAddTag = {}
+            onAddTag = { true },
+            onRemoveTag = {}
         )
     }
 }

--- a/core/ui/src/main/java/com/core/ui/tag/Tag.kt
+++ b/core/ui/src/main/java/com/core/ui/tag/Tag.kt
@@ -35,7 +35,7 @@ fun TagContainer(
     modifier: Modifier = Modifier,
     tags: List<TagUiModel>,
     tagSpace: Dp = 2.dp,
-    onAddTag: (String) -> Boolean,
+    onAddTag: (String) -> Unit,
     onRemoveTag: (TagUiModel) -> Unit
 ) {
     val showTagTextField = remember { mutableStateOf(false) }
@@ -47,7 +47,7 @@ fun TagContainer(
             crossAxisSpacing = tagSpace
         ) {
             tags.forEach { tag ->
-                TagChip(name = tag.name, onClick = { onRemoveTag(tag) })
+                TagChip(name = "#${tag.name}", onClick = { onRemoveTag(tag) })
             }
             TagChip(
                 name = "+태그추가",
@@ -61,11 +61,7 @@ fun TagContainer(
             )
         ) {
             TagTextField(
-                onAddTag = {
-                    // tag 를 성공적으로 추가한 경우에만 태그 입력란 hide
-                    val isSuccess = onAddTag(it)
-                    if (isSuccess) showTagTextField.value = false
-                }
+                onAddTag = onAddTag
             )
         }
     }
@@ -107,7 +103,10 @@ fun TagTextField(
             )
             HarooButton(
                 alpha = 0f,
-                onClick = { onAddTag(tag.value) }
+                onClick = {
+                    onAddTag(tag.value)
+                    tag.value = ""
+                }
             ) {
                 Icon(
                     imageVector = Icons.Outlined.Add,
@@ -145,7 +144,7 @@ fun TagContainerPreview() {
                 TagUiModel(name = "test5"),
                 TagUiModel(name = "test6")
             ),
-            onAddTag = { true },
+            onAddTag = { },
             onRemoveTag = {}
         )
     }

--- a/core/ui/src/main/java/com/core/ui/tag/Tag.kt
+++ b/core/ui/src/main/java/com/core/ui/tag/Tag.kt
@@ -1,5 +1,9 @@
 package com.core.ui.tag
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -20,6 +24,27 @@ import com.core.designsystem.components.HarooDivider
 import com.core.designsystem.components.HarooTextField
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.core.model.feature.TagUiModel
+
+
+@Composable
+fun TagContainer(
+    modifier: Modifier = Modifier,
+    tags: List<TagUiModel>,
+    onAddTag: (TagUiModel) -> Unit
+) {
+    val showTagTextField = remember { mutableStateOf(true) }
+
+    Column {
+        AnimatedVisibility(
+            visible = showTagTextField.value,
+            enter = expandVertically(
+                animationSpec = tween(durationMillis = 250, easing = LinearEasing)
+            )
+        ) {
+            TagTextField(onAddTag = onAddTag)
+        }
+    }
+}
 
 @Composable
 fun TagTextField(
@@ -63,5 +88,13 @@ fun TagTextFieldPreview() {
         TagTextField(
             onAddTag = {}
         )
+    }
+}
+
+@Composable
+@Preview(name = "basic tag container")
+fun TagContainerPreview() {
+    AllForMemoryTheme {
+        TagContainer(tags = emptyList(), onAddTag = {})
     }
 }

--- a/core/ui/src/main/java/com/core/ui/tag/Tag.kt
+++ b/core/ui/src/main/java/com/core/ui/tag/Tag.kt
@@ -100,6 +100,7 @@ fun TagTextField(
                 modifier = Modifier.weight(1f),
                 value = tag.value,
                 onValueChange = { tag.value = it },
+                autoFocus = true,
                 color = Color.Transparent,
                 placeHolder = "태그 입력...",
                 contentPadding = PaddingValues(horizontal = 8.dp)

--- a/core/ui/src/main/java/com/core/ui/tag/Tag.kt
+++ b/core/ui/src/main/java/com/core/ui/tag/Tag.kt
@@ -29,7 +29,6 @@ import com.core.designsystem.theme.AllForMemoryTheme
 import com.core.model.feature.TagUiModel
 import com.google.accompanist.flowlayout.FlowRow
 
-
 @Composable
 fun TagContainer(
     modifier: Modifier = Modifier,
@@ -85,6 +84,12 @@ fun TagTextField(
     onAddTag: (String) -> Unit
 ) {
     val tag = remember { mutableStateOf("") }
+    val onAddTagAndClearTag = remember(key1 = onAddTag) {
+        {
+            onAddTag(tag.value)
+            tag.value = ""
+        }
+    }
 
     Column(
         modifier = modifier.fillMaxWidth()
@@ -99,14 +104,12 @@ fun TagTextField(
                 autoFocus = true,
                 color = Color.Transparent,
                 placeHolder = "태그 입력...",
-                contentPadding = PaddingValues(horizontal = 8.dp)
+                contentPadding = PaddingValues(horizontal = 8.dp),
+                onDone = { onAddTagAndClearTag() }
             )
             HarooButton(
                 alpha = 0f,
-                onClick = {
-                    onAddTag(tag.value)
-                    tag.value = ""
-                }
+                onClick = onAddTagAndClearTag
             ) {
                 Icon(
                     imageVector = Icons.Outlined.Add,

--- a/core/ui/src/main/java/com/core/ui/tag/Tag.kt
+++ b/core/ui/src/main/java/com/core/ui/tag/Tag.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Icon
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.runtime.Composable
@@ -18,32 +19,64 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.core.designsystem.components.HarooButton
+import com.core.designsystem.components.HarooChip
 import com.core.designsystem.components.HarooDivider
 import com.core.designsystem.components.HarooTextField
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.core.model.feature.TagUiModel
+import com.google.accompanist.flowlayout.FlowRow
 
 
 @Composable
 fun TagContainer(
     modifier: Modifier = Modifier,
     tags: List<TagUiModel>,
+    tagSpace: Dp = 2.dp,
     onAddTag: (TagUiModel) -> Unit
 ) {
-    val showTagTextField = remember { mutableStateOf(true) }
+    val showTagTextField = remember { mutableStateOf(false) }
 
-    Column {
+    Column(modifier = modifier) {
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            mainAxisSpacing = tagSpace,
+            crossAxisSpacing = tagSpace
+        ) {
+            tags.forEach { tag -> TagChip(name = tag.name, onClick = {}) }
+            TagChip(
+                name = "+태그추가",
+                onClick = { showTagTextField.value = true }
+            )
+        }
         AnimatedVisibility(
             visible = showTagTextField.value,
             enter = expandVertically(
                 animationSpec = tween(durationMillis = 250, easing = LinearEasing)
             )
         ) {
-            TagTextField(onAddTag = onAddTag)
+            TagTextField(
+                onAddTag = {
+                    onAddTag(it)
+                    showTagTextField.value = false
+                }
+            )
         }
     }
+}
+
+@Composable
+fun TagChip(
+    name: String,
+    onClick: () -> Unit
+) {
+    HarooChip(
+        onClick = onClick,
+        border = null,
+        alpha = 0.25f
+    ) { Text(text = name) }
 }
 
 @Composable
@@ -95,6 +128,19 @@ fun TagTextFieldPreview() {
 @Preview(name = "basic tag container")
 fun TagContainerPreview() {
     AllForMemoryTheme {
-        TagContainer(tags = emptyList(), onAddTag = {})
+        TagContainer(
+            tags = listOf(
+                TagUiModel(name = "자유여행"),
+                TagUiModel(name = "친구와함께"),
+                TagUiModel(name = "제주도"),
+                TagUiModel(name = "test1"),
+                TagUiModel(name = "test2"),
+                TagUiModel(name = "test3"),
+                TagUiModel(name = "test4"),
+                TagUiModel(name = "test5"),
+                TagUiModel(name = "test6")
+            ),
+            onAddTag = {}
+        )
     }
 }

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -70,7 +70,9 @@ fun PostScreen(
             }
             TagContainer(
                 modifier = Modifier.padding(horizontal = 12.dp),
-                tags = emptyList(), onAddTag = {}
+                tags = emptyList(),
+                onAddTag = postViewModel::addTag,
+                onRemoveTag = postViewModel::removeTag
             )
             BottomAppBar(
                 modifier = Modifier.padding(vertical = 12.dp),

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -18,6 +18,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.core.designsystem.theme.HarooTheme
 import com.core.ui.gallery.DrawerGalleryContainer
 import com.core.ui.gallery.GalleryListContainer
+import com.core.ui.tag.TagContainer
 import kotlinx.coroutines.launch
 
 @ExperimentalMaterialApi
@@ -67,6 +68,10 @@ fun PostScreen(
             Column(modifier = Modifier.weight(1f)) {
 
             }
+            TagContainer(
+                modifier = Modifier.padding(horizontal = 12.dp),
+                tags = emptyList(), onAddTag = {}
+            )
             BottomAppBar(
                 modifier = Modifier.padding(vertical = 12.dp),
                 backgroundColor = Color.Transparent

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -2,24 +2,23 @@ package com.feature.post
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.BottomAppBar
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.core.designsystem.components.HarooBottomDrawer
+import com.core.designsystem.components.rememberHarooBottomDrawerState
 import com.core.designsystem.theme.HarooTheme
 import com.core.ui.gallery.DrawerGalleryContainer
 import com.core.ui.gallery.GalleryListContainer
 import com.core.ui.tag.TagContainer
-import kotlinx.coroutines.launch
 
 @ExperimentalMaterialApi
 @Composable
@@ -29,36 +28,31 @@ fun PostScreen(
     val images = postViewModel.images.collectAsLazyPagingItems()
     val selectedImages = postViewModel.selectedImages.collectAsState()
     val tags = postViewModel.tags.collectAsState()
+    val bottomDrawerState = rememberHarooBottomDrawerState()
 
-    val coroutineScope = rememberCoroutineScope()
-    val bottomDrawerState = rememberBottomDrawerState(initialValue = BottomDrawerValue.Closed)
-
-    BackHandler(enabled = bottomDrawerState.isOpen) {
-        coroutineScope.launch {
-            bottomDrawerState.close()
-        }
+    BackHandler(enabled = bottomDrawerState.isShow.value) {
+        bottomDrawerState.hide()
     }
 
-    BottomDrawer(
+    HarooBottomDrawer(
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .imePadding(),
         drawerState = bottomDrawerState,
         drawerContent = {
             DrawerGalleryContainer(
-                drawerState = bottomDrawerState,
                 images = images,
                 selectedImages = selectedImages.value,
                 limit = PostViewModel.IMAGE_SELECT_LIMIT,
                 space = 2.dp,
-                onClose = {
-                    coroutineScope.launch { bottomDrawerState.close() }
-                },
+                onClose = { bottomDrawerState.hide() },
                 onImageSelect = {
                     postViewModel.setImages(it)
-                    coroutineScope.launch { bottomDrawerState.close() }
+                    bottomDrawerState.hide()
                 }
             )
-        },
-        gesturesEnabled = false,
-        scrimColor = HarooTheme.colors.dim
+        }
     ) {
         Column(
             modifier = Modifier
@@ -83,12 +77,11 @@ fun PostScreen(
                     images = images,
                     selectedImages = selectedImages.value,
                     limit = PostViewModel.IMAGE_SELECT_LIMIT,
-                    onClickAddButton = {
-                        coroutineScope.launch { bottomDrawerState.expand() }
-                    },
+                    onClickAddButton = { bottomDrawerState.show() },
                     onImageSelect = postViewModel::selectImage
                 )
             }
         }
     }
 }
+//}

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -5,10 +5,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.BottomAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -19,9 +23,11 @@ import com.core.ui.gallery.DrawerGalleryContainer
 import com.core.ui.gallery.GalleryListContainer
 import com.core.ui.tag.TagContainer
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PostScreen(
-    postViewModel: PostViewModel = hiltViewModel()
+    postViewModel: PostViewModel = hiltViewModel(),
+    keyboardController: SoftwareKeyboardController? = LocalSoftwareKeyboardController.current
 ) {
     val images = postViewModel.images.collectAsLazyPagingItems()
     val selectedImages = postViewModel.selectedImages.collectAsState()
@@ -30,6 +36,12 @@ fun PostScreen(
 
     BackHandler(enabled = bottomDrawerState.isShow.value) {
         bottomDrawerState.hide()
+    }
+
+    LaunchedEffect(key1 = bottomDrawerState.isShow.value) {
+        if (bottomDrawerState.isShow.value) {
+            keyboardController?.hide()
+        }
     }
 
     HarooBottomDrawer(

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -5,14 +5,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.BottomAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -23,11 +19,9 @@ import com.core.ui.gallery.DrawerGalleryContainer
 import com.core.ui.gallery.GalleryListContainer
 import com.core.ui.tag.TagContainer
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PostScreen(
-    postViewModel: PostViewModel = hiltViewModel(),
-    keyboardController: SoftwareKeyboardController? = LocalSoftwareKeyboardController.current
+    postViewModel: PostViewModel = hiltViewModel()
 ) {
     val images = postViewModel.images.collectAsLazyPagingItems()
     val selectedImages = postViewModel.selectedImages.collectAsState()
@@ -36,12 +30,6 @@ fun PostScreen(
 
     BackHandler(enabled = bottomDrawerState.isShow.value) {
         bottomDrawerState.hide()
-    }
-
-    LaunchedEffect(key1 = bottomDrawerState.isShow.value) {
-        if (bottomDrawerState.isShow.value) {
-            keyboardController?.hide()
-        }
     }
 
     HarooBottomDrawer(

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.BottomAppBar
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
@@ -20,7 +19,6 @@ import com.core.ui.gallery.DrawerGalleryContainer
 import com.core.ui.gallery.GalleryListContainer
 import com.core.ui.tag.TagContainer
 
-@ExperimentalMaterialApi
 @Composable
 fun PostScreen(
     postViewModel: PostViewModel = hiltViewModel()

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -28,8 +28,8 @@ fun PostScreen(
 ) {
     val images = postViewModel.images.collectAsLazyPagingItems()
     val selectedImages = postViewModel.selectedImages.collectAsState()
+    val tags = postViewModel.tags.collectAsState()
 
-//    val modalSheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
     val coroutineScope = rememberCoroutineScope()
     val bottomDrawerState = rememberBottomDrawerState(initialValue = BottomDrawerValue.Closed)
 
@@ -70,7 +70,7 @@ fun PostScreen(
             }
             TagContainer(
                 modifier = Modifier.padding(horizontal = 12.dp),
-                tags = emptyList(),
+                tags = tags.value,
                 onAddTag = postViewModel::addTag,
                 onRemoveTag = postViewModel::removeTag
             )

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -43,13 +43,12 @@ class PostViewModel @Inject constructor(
         _selectedImages.value = selectedImages
     }
 
-    fun addTag(name: String): Boolean {
+    fun addTag(name: String) {
         // 빈칸을 입력한 경우
-        if (name.isBlank()) return false
+        if (name.isBlank()) return
         // 동일한 이름의 tag 가 이미 존재 하는 경우
-        if (_tags.value.any { it.name == name }) return false
+        if (_tags.value.any { it.name == name }) return
         _tags.value += TagUiModel(name = name)
-        return true
     }
 
     fun removeTag(tagUiModel: TagUiModel) {

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -7,6 +7,7 @@ import androidx.paging.map
 import com.core.domain.post.GetImagesUseCase
 import com.core.model.domain.toImageUiModel
 import com.core.model.feature.ImageUiModel
+import com.core.model.feature.TagUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +28,9 @@ class PostViewModel @Inject constructor(
     private val _selectedImages = MutableStateFlow<List<ImageUiModel>>(emptyList())
     val selectedImages: StateFlow<List<ImageUiModel>> = _selectedImages.asStateFlow()
 
+    private val _tags = MutableStateFlow<List<TagUiModel>>(emptyList())
+    val tags: StateFlow<List<TagUiModel>> = _tags.asStateFlow()
+
     fun selectImage(imageUiModel: ImageUiModel) {
         if (imageUiModel in _selectedImages.value) {
             _selectedImages.value = _selectedImages.value.filterNot { it == imageUiModel }
@@ -37,6 +41,19 @@ class PostViewModel @Inject constructor(
 
     fun setImages(selectedImages: List<ImageUiModel>) {
         _selectedImages.value = selectedImages
+    }
+
+    fun addTag(name: String): Boolean {
+        // 빈칸을 입력한 경우
+        if (_tags.value.isEmpty()) return false
+        // 동일한 이름의 tag 가 이미 존재 하는 경우
+        if (_tags.value.any { it.name == name }) return false
+        _tags.value += TagUiModel(name = name)
+        return true
+    }
+
+    fun removeTag(tagUiModel: TagUiModel) {
+        _tags.value = _tags.value.filterNot { it == tagUiModel }
     }
 
     companion object {

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -45,7 +45,7 @@ class PostViewModel @Inject constructor(
 
     fun addTag(name: String): Boolean {
         // 빈칸을 입력한 경우
-        if (_tags.value.isEmpty()) return false
+        if (name.isBlank()) return false
         // 동일한 이름의 tag 가 이미 존재 하는 경우
         if (_tags.value.any { it.name == name }) return false
         _tags.value += TagUiModel(name = name)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+accompanist = "0.28.0"
 androidGradlePlugin = "7.4.2"
 androidGradleTool = "7.2.0"
 androidx-lifecycle-runtime-compose = '2.6.0-alpha03'
@@ -69,6 +70,9 @@ paging-compose = { group = "androidx.paging", name = "paging-compose", version.r
 # coil
 coil-kt = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 coil-kt-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+
+# accompanist
+accompanist-flowlayout = { group = "com.google.accompanist", name = "accompanist-flowlayout", version.ref = "accompanist" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
### 📌 내용
태그를 입력하고 추가한 태그가 보이는 리스트와 관련된 Component를 구성하고 Post Screen에 추가

### 🛠 Done
- [x] 태그 입력 Component
- [x] 태그 리스트 Component
- [x] 태그 추가 Chip 클릭 시, 태그 입력 Component가 보이도록 처리
- [x] 태그 추가 버튼 클릭 시, 태그 리스트에 추가
- [x] keyboard가 부드럽게 slide되도록 처리하기

### 🪴 UI
<img height="250" src="https://user-images.githubusercontent.com/22411296/230912531-a43a4392-e88b-4cf3-9a37-405785e9ade8.jpeg"/>

### 🌹 To Do
- [ ] 태그 입력 EditText와 게시글 내용 입력 EditText간의 focus UseCase 정리하기

### 🏠 관련 Issue
Closed #23 