### PR TITLE
[FEAT] #28 PostScreen Business 로직 추가

### DIFF
--- a/app/src/main/java/com/haman/allformemory/MainActivity.kt
+++ b/app/src/main/java/com/haman/allformemory/MainActivity.kt
@@ -7,11 +7,11 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.core.view.WindowCompat
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.feature.post.PostScreen
 import dagger.hilt.android.AndroidEntryPoint
+import java.time.LocalDate
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -25,7 +25,6 @@ class MainActivity : ComponentActivity() {
             }
         }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -40,7 +39,12 @@ class MainActivity : ComponentActivity() {
                         requestPermissionLauncher.launch(arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE))
                     }
                 }
-                PostScreen()
+                val date = LocalDate.now()
+                PostScreen(
+                    year = date.year,
+                    month = date.monthValue,
+                    day = date.dayOfMonth
+                )
             }
         }
     }

--- a/core/data/src/main/java/com/core/data/image/datastore/ImageDataStorePagingSource.kt
+++ b/core/data/src/main/java/com/core/data/image/datastore/ImageDataStorePagingSource.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.core.datastore.ImageDatastore
 import com.core.model.data.ImageSource
-import com.core.model.datastore.toImageSource
+import com.core.model.data.toSource
 import kotlinx.coroutines.coroutineScope
 
 class ImageDataStorePagingSource(
@@ -23,7 +23,7 @@ class ImageDataStorePagingSource(
 
             try {
                 val images =
-                    imageDatastore.getImages(PAGING_SIZE, offset).map { it.toImageSource() }
+                    imageDatastore.getImages(PAGING_SIZE, offset).map { it.toSource() }
 
                 LoadResult.Page(
                     prevKey = if (offset == INIT_OFFSET) null else offset - PAGING_SIZE,

--- a/core/data/src/main/java/com/core/data/post/PostRepository.kt
+++ b/core/data/src/main/java/com/core/data/post/PostRepository.kt
@@ -1,7 +1,9 @@
 package com.core.data.post
 
 import androidx.paging.PagingData
+import com.core.model.data.ImageSource
 import com.core.model.data.PostSource
+import com.core.model.data.TagSource
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -9,7 +11,11 @@ import kotlinx.coroutines.flow.Flow
  */
 interface PostRepository {
     // post 추가
-    suspend fun addPost(post: PostSource): Long
+    suspend fun addPost(
+        post: PostSource,
+        removeImages: List<ImageSource>,
+        removeTags: List<TagSource>
+    ): Long
 
     // 특정 년도/월/일 post 요청
     suspend fun getPost(year: Int, month: Int, day: Int): PostSource?

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalPagingSource.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalPagingSource.kt
@@ -4,8 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.core.database.dao.PostDao
 import com.core.model.data.PostSource
-import com.core.model.database.toImageSource
-import com.core.model.database.toTag
+import com.core.model.data.toSource
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -40,8 +39,8 @@ class PostLocalPagingSource(
                                     month = post.month,
                                     day = post.day,
                                     content = post.content,
-                                    images = images.await().map { image -> image.toImageSource() },
-                                    tags = tags.await().map { tag -> tag.toTag() }
+                                    images = images.await().map { image -> image.toSource() },
+                                    tags = tags.await().map { tag -> tag.toSource() }
                                 )
                             }
                         }

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
@@ -5,12 +5,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.core.data.post.PostRepository
 import com.core.database.dao.PostDao
-import com.core.model.data.PostSource
-import com.core.model.data.toImageEntity
-import com.core.model.data.toPostEntity
-import com.core.model.data.toTagEntity
-import com.core.model.database.toImageSource
-import com.core.model.database.toTag
+import com.core.model.data.*
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -43,8 +38,8 @@ class PostLocalRepositoryImpl @Inject constructor(
                 month = post.month,
                 day = post.day,
                 content = post.content,
-                images = images.await().map { image -> image.toImageSource() },
-                tags = tags.await().map { tag -> tag.toTag() }
+                images = images.await().map { image -> image.toSource() },
+                tags = tags.await().map { tag -> tag.toSource() }
             )
         }
     }
@@ -63,8 +58,8 @@ class PostLocalRepositoryImpl @Inject constructor(
                             month = post.month,
                             day = post.day,
                             content = post.content,
-                            images = images.await().map { image -> image.toImageSource() },
-                            tags = tags.await().map { tag -> tag.toTag() }
+                            images = images.await().map { image -> image.toSource() },
+                            tags = tags.await().map { tag -> tag.toSource() }
                         )
                     }
                 }

--- a/core/database/src/main/java/com/core/database/dao/PostDao.kt
+++ b/core/database/src/main/java/com/core/database/dao/PostDao.kt
@@ -1,9 +1,6 @@
 package com.core.database.dao
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room.*
 import com.core.model.database.ImageEntity
 import com.core.model.database.PostEntity
 import com.core.model.database.TagEntity
@@ -40,4 +37,10 @@ interface PostDao {
     // 특정 post 의 tag 요청
     @Query("SELECT * FROM tag WHERE post_id = :postId")
     suspend fun selectTagsByPost(postId: Long): List<TagEntity>
+
+    @Delete
+    suspend fun deleteImages(images: List<ImageEntity>)
+
+    @Delete
+    suspend fun deleteTags(tags: List<TagEntity>)
 }

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Button.kt
@@ -26,8 +26,11 @@ fun HarooButton(
     onClick: () -> Unit,
     enabled: Boolean = true, // 사용 가능 여부
     shape: Shape = MaterialTheme.shapes.small,
-    border: BorderStroke? = null, // 테두리 모양
-    alpha: Float = 1f, // 배경색 투명도
+    border: BorderStroke? = BorderStroke(
+        width = 1.dp,
+        color = HarooTheme.colors.uiBorder
+    ), // 테두리 모양
+    alpha: Float = 0f, // 배경색 투명도
     backgroundColor: Color = Color.Unspecified, // 배경 색
     disableBackgroundColor: Color = Color.Unspecified, // disable 일때 배경 색
     contentColor: Color = HarooTheme.colors.text, // 내부 색

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
@@ -37,6 +37,7 @@ import com.core.model.feature.ImageUiModel
 @Composable
 fun RemovableImage(
     modifier: Modifier = Modifier,
+    isEditMode: () -> Boolean = { true },
     image: ImageUiModel,
     shape: Shape = MaterialTheme.shapes.medium,
     elevation: Dp = 0.dp,
@@ -57,6 +58,7 @@ fun RemovableImage(
                 modifier = Modifier.layoutId("RemoveBtn"),
                 onClick = { onRemove(image) },
                 backgroundColor = HarooTheme.colors.dim,
+                border = null,
                 alpha = 0.5f,
                 contentPadding = PaddingValues(2.dp)
             ) {
@@ -68,13 +70,6 @@ fun RemovableImage(
             }
         }
     ) { measureables, constraints ->
-        val removeButtonSize = (constraints.maxHeight / 5).coerceIn(0, 25.dp.toPx().toInt())
-        val removePlaceable = measureables.find { it.layoutId == "RemoveBtn" }?.measure(
-            Constraints(
-                minWidth = removeButtonSize, maxWidth = removeButtonSize,
-                minHeight = removeButtonSize, maxHeight = removeButtonSize
-            )
-        )
         val imagePlaceable = measureables.find { it.layoutId == "Image" }?.measure(constraints)
         val imageWidth = imagePlaceable?.width ?: constraints.minWidth
 
@@ -83,7 +78,19 @@ fun RemovableImage(
             constraints.maxHeight
         ) {
             imagePlaceable?.placeRelative(x = 0, y = 0)
-            removePlaceable?.placeRelative(x = imageWidth - removeButtonSize - 4, y = 4)
+            if (isEditMode()) {
+                val removeButtonSize = (constraints.maxHeight / 5).coerceIn(0, 25.dp.toPx().toInt())
+                val removePlaceable = measureables.find { it.layoutId == "RemoveBtn" }?.measure(
+                    Constraints(
+                        minWidth = removeButtonSize, maxWidth = removeButtonSize,
+                        minHeight = removeButtonSize, maxHeight = removeButtonSize
+                    )
+                )
+                removePlaceable?.placeRelative(
+                    x = imageWidth - removeButtonSize - 4,
+                    y = 4
+                )
+            }
         }
     }
 }

--- a/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/TextField.kt
@@ -49,7 +49,9 @@ fun HarooTextField(
 ) {
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(key1 = autoFocus) {
-        if (autoFocus) focusRequester.requestFocus()
+        if (autoFocus) {
+            focusRequester.requestFocus()
+        }
     }
 
     HarooSurface(

--- a/core/designsystem/src/main/java/com/core/designsystem/util/Resources.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/util/Resources.kt
@@ -1,0 +1,10 @@
+package com.core.designsystem.util
+
+import androidx.annotation.DimenRes
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+
+@Composable
+fun getString(@StringRes id: Int) = stringResource(id = id)

--- a/core/domain/src/main/java/com/core/domain/post/AddPostUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/AddPostUseCase.kt
@@ -1,0 +1,17 @@
+package com.core.domain.post
+
+import com.core.data.post.PostRepository
+import com.core.model.domain.Post
+import com.core.model.domain.toSource
+import javax.inject.Inject
+
+/**
+ * 게시글 추가 use case
+ */
+class AddPostUseCase @Inject constructor(
+    private val postRepository: PostRepository
+) {
+    suspend operator fun invoke(post: Post): Long {
+        return postRepository.addPost(post.toSource())
+    }
+}

--- a/core/domain/src/main/java/com/core/domain/post/AddPostUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/AddPostUseCase.kt
@@ -1,7 +1,9 @@
 package com.core.domain.post
 
 import com.core.data.post.PostRepository
+import com.core.model.domain.Image
 import com.core.model.domain.Post
+import com.core.model.domain.Tag
 import com.core.model.domain.toSource
 import javax.inject.Inject
 
@@ -11,7 +13,14 @@ import javax.inject.Inject
 class AddPostUseCase @Inject constructor(
     private val postRepository: PostRepository
 ) {
-    suspend operator fun invoke(post: Post): Long {
-        return postRepository.addPost(post.toSource())
+    suspend operator fun invoke(
+        post: Post,
+        removeImages: List<Image>,
+        removeTags: List<Tag>
+    ): Long {
+        return postRepository.addPost(
+            post.toSource(),
+            removeImages.map { it.toSource() },
+            removeTags = removeTags.map { it.toSource() })
     }
 }

--- a/core/domain/src/main/java/com/core/domain/post/GetImagesUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/GetImagesUseCase.kt
@@ -3,8 +3,8 @@ package com.core.domain.post
 import androidx.paging.PagingData
 import androidx.paging.map
 import com.core.data.image.ImageRepository
-import com.core.model.data.toImage
 import com.core.model.domain.Image
+import com.core.model.domain.toImage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject

--- a/core/domain/src/main/java/com/core/domain/post/GetPostByDateUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/GetPostByDateUseCase.kt
@@ -1,10 +1,17 @@
 package com.core.domain.post
 
+import com.core.data.post.PostRepository
+import com.core.model.domain.Post
+import com.core.model.domain.toPost
+import javax.inject.Inject
+
 /**
  * 일별 기록 요청 use case
  */
-class GetPostByDateUseCase {
-    suspend operator fun invoke(year: Int, month: Int, day: Int) {
-
+class GetPostByDateUseCase @Inject constructor(
+    private val postRepository: PostRepository
+) {
+    suspend operator fun invoke(year: Int, month: Int, day: Int): Post? {
+        return postRepository.getPost(year, month, day)?.toPost()
     }
 }

--- a/core/model/src/main/java/com/core/model/data/ImageSource.kt
+++ b/core/model/src/main/java/com/core/model/data/ImageSource.kt
@@ -1,7 +1,7 @@
 package com.core.model.data
 
 import com.core.model.database.ImageEntity
-import com.core.model.domain.Image
+import com.core.model.datastore.ImageData
 
 /**
  * datasource Image 정보
@@ -17,7 +17,12 @@ fun ImageSource.toImageEntity(postId: Long) = ImageEntity(
     imageUrl = imageUrl
 )
 
-fun ImageSource.toImage() = Image(
+fun ImageEntity.toSource() = ImageSource(
     id = id,
     imageUrl = imageUrl
+)
+
+fun ImageData.toSource() = ImageSource(
+    id = id,
+    imageUrl = imageUrl.toString()
 )

--- a/core/model/src/main/java/com/core/model/data/TagSource.kt
+++ b/core/model/src/main/java/com/core/model/data/TagSource.kt
@@ -15,3 +15,8 @@ fun TagSource.toTagEntity(postId: Long) = TagEntity(
     postId = postId,
     name = name
 )
+
+fun TagEntity.toSource() = TagSource(
+    id = id,
+    name = name
+)

--- a/core/model/src/main/java/com/core/model/database/ImageEntity.kt
+++ b/core/model/src/main/java/com/core/model/database/ImageEntity.kt
@@ -5,7 +5,6 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.ForeignKey.CASCADE
 import androidx.room.PrimaryKey
-import com.core.model.data.ImageSource
 
 /**
  * Image Table
@@ -28,9 +27,4 @@ data class ImageEntity(
     val postId: Long,
     @ColumnInfo(name = "image_url")
     val imageUrl: String
-)
-
-fun ImageEntity.toImageSource() = ImageSource(
-    id = id,
-    imageUrl = imageUrl
 )

--- a/core/model/src/main/java/com/core/model/database/TagEntity.kt
+++ b/core/model/src/main/java/com/core/model/database/TagEntity.kt
@@ -5,7 +5,6 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.ForeignKey.CASCADE
 import androidx.room.PrimaryKey
-import com.core.model.data.TagSource
 
 @Entity(
     tableName = "tag",
@@ -24,9 +23,4 @@ data class TagEntity(
     @ColumnInfo(name = "post_id", index = true)
     val postId: Long?,
     val name: String
-)
-
-fun TagEntity.toTag() = TagSource(
-    id = id,
-    name = name
 )

--- a/core/model/src/main/java/com/core/model/datastore/ImageData.kt
+++ b/core/model/src/main/java/com/core/model/datastore/ImageData.kt
@@ -1,14 +1,8 @@
 package com.core.model.datastore
 
 import android.net.Uri
-import com.core.model.data.ImageSource
 
 data class ImageData(
     val id: Long,
     val imageUrl: Uri
-)
-
-fun ImageData.toImageSource() = ImageSource(
-    id = id,
-    imageUrl = imageUrl.toString()
 )

--- a/core/model/src/main/java/com/core/model/domain/Image.kt
+++ b/core/model/src/main/java/com/core/model/domain/Image.kt
@@ -1,13 +1,18 @@
 package com.core.model.domain
 
-import com.core.model.feature.ImageUiModel
+import com.core.model.data.ImageSource
 
 data class Image(
     val id: Long?,
     val imageUrl: String
 )
 
-fun Image.toImageUiModel() = ImageUiModel(
+fun Image.toSource() = ImageSource(
+    id = id,
+    imageUrl = imageUrl
+)
+
+fun ImageSource.toImage() = Image(
     id = id,
     imageUrl = imageUrl
 )

--- a/core/model/src/main/java/com/core/model/domain/Post.kt
+++ b/core/model/src/main/java/com/core/model/domain/Post.kt
@@ -24,3 +24,13 @@ fun Post.toSource() = PostSource(
     images = images.map { it.toSource() },
     tags = tags.map { it.toSource() }
 )
+
+fun PostSource.toPost() = Post(
+    id = id,
+    year = year,
+    month = month,
+    day = day,
+    content = content,
+    images = images.map { it.toImage() },
+    tags = tags.map { it.toTag() }
+)

--- a/core/model/src/main/java/com/core/model/domain/Post.kt
+++ b/core/model/src/main/java/com/core/model/domain/Post.kt
@@ -1,0 +1,26 @@
+package com.core.model.domain
+
+import com.core.model.data.PostSource
+
+/**
+ * domain Layer: Post 정보
+ */
+data class Post(
+    val id: Long?, // post id
+    val year: Int,
+    val month: Int,
+    val day: Int,
+    val content: String?,
+    val images: List<Image>,
+    val tags: List<Tag>
+)
+
+fun Post.toSource() = PostSource(
+    id = id,
+    year = year,
+    month = month,
+    day = day,
+    content = content,
+    images = images.map { it.toSource() },
+    tags = tags.map { it.toSource() }
+)

--- a/core/model/src/main/java/com/core/model/domain/Tag.kt
+++ b/core/model/src/main/java/com/core/model/domain/Tag.kt
@@ -1,0 +1,16 @@
+package com.core.model.domain
+
+import com.core.model.data.TagSource
+
+/**
+ * domain Layer: Tag 정보
+ */
+data class Tag(
+    val id: Long?,
+    val name: String
+)
+
+fun Tag.toSource() = TagSource(
+    id = id,
+    name = name
+)

--- a/core/model/src/main/java/com/core/model/domain/Tag.kt
+++ b/core/model/src/main/java/com/core/model/domain/Tag.kt
@@ -14,3 +14,8 @@ fun Tag.toSource() = TagSource(
     id = id,
     name = name
 )
+
+fun TagSource.toTag() = Tag(
+    id = id,
+    name = name
+)

--- a/core/model/src/main/java/com/core/model/feature/ImageUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/ImageUiModel.kt
@@ -5,9 +5,14 @@ import com.core.model.domain.Image
 data class ImageUiModel(
     override val id: Long?,
     val imageUrl: String
-): Model(id, CellType.IMAGE)
+) : Model(id, CellType.IMAGE)
 
 fun Image.toImageUiModel() = ImageUiModel(
+    id = id,
+    imageUrl = imageUrl
+)
+
+fun ImageUiModel.toImage() = Image(
     id = id,
     imageUrl = imageUrl
 )

--- a/core/model/src/main/java/com/core/model/feature/ImageUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/ImageUiModel.kt
@@ -1,6 +1,13 @@
 package com.core.model.feature
 
+import com.core.model.domain.Image
+
 data class ImageUiModel(
     override val id: Long?,
     val imageUrl: String
 ): Model(id, CellType.IMAGE)
+
+fun Image.toImageUiModel() = ImageUiModel(
+    id = id,
+    imageUrl = imageUrl
+)

--- a/core/model/src/main/java/com/core/model/feature/TagUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/TagUiModel.kt
@@ -1,5 +1,7 @@
 package com.core.model.feature
 
+import com.core.model.domain.Tag
+
 /**
  * tag 정보를 위한 ui model
  */
@@ -7,3 +9,5 @@ data class TagUiModel(
     override val id: Long? = null,
     val name: String
 ) : Model(id, CellType.TAG)
+
+fun TagUiModel.toTag() = Tag(id = id, name = name)

--- a/core/model/src/main/java/com/core/model/feature/TagUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/TagUiModel.kt
@@ -11,3 +11,5 @@ data class TagUiModel(
 ) : Model(id, CellType.TAG)
 
 fun TagUiModel.toTag() = Tag(id = id, name = name)
+
+fun Tag.toTagUiModel() = TagUiModel(id = id, name = name)

--- a/core/ui/src/main/java/com/core/ui/gallery/GalleryListContainer.kt
+++ b/core/ui/src/main/java/com/core/ui/gallery/GalleryListContainer.kt
@@ -42,6 +42,7 @@ fun GalleryListContainer(
             shape = MaterialTheme.shapes.medium,
             backgroundColor = HarooTheme.colors.uiBackground,
             alpha = 0.1f,
+            border = null,
             contentColor = HarooTheme.colors.text,
             content = {
                 Icon(

--- a/core/ui/src/main/java/com/core/ui/image/ImageList.kt
+++ b/core/ui/src/main/java/com/core/ui/image/ImageList.kt
@@ -18,23 +18,23 @@ fun AsyncImageLazyRow(
     modifier: Modifier = Modifier,
     images: List<ImageUiModel>,
     space: Dp = 0.dp,
-    contentPadding: Dp = 0.dp,
+    contentPadding: PaddingValues = PaddingValues(),
     content: @Composable (ImageUiModel) -> Unit
 ) {
     AnimatedVisibility(visible = images.isNotEmpty()) {
         Row(
             modifier = modifier
-                .padding(vertical = contentPadding)
+                .padding(contentPadding)
                 .horizontalScroll(
                     rememberScrollState()
                 ),
             horizontalArrangement = Arrangement.spacedBy(space),
         ) {
-            Spacer(modifier = Modifier.width(contentPadding))
+            Spacer(modifier = Modifier.width(space))
             images.forEach {
                 content(it)
             }
-            Spacer(modifier = Modifier.width(contentPadding))
+            Spacer(modifier = Modifier.width(space))
         }
     }
 }

--- a/core/ui/src/main/java/com/core/ui/tag/Tag.kt
+++ b/core/ui/src/main/java/com/core/ui/tag/Tag.kt
@@ -35,6 +35,7 @@ import com.google.accompanist.flowlayout.FlowRow
 @Composable
 fun TagContainer(
     modifier: Modifier = Modifier,
+    isEditMode: Boolean = true,
     showTagTextFieldFlag: Boolean = false,
     tags: List<TagUiModel>,
     tagSpace: Dp = 2.dp,
@@ -51,7 +52,7 @@ fun TagContainer(
             tags.forEach { tag ->
                 TagChip(name = "#${tag.name}", onClick = { onRemoveTag(tag) })
             }
-            if (showTagTextFieldFlag.not()) {
+            if (isEditMode && showTagTextFieldFlag.not()) {
                 TagChip(
                     name = "+태그추가",
                     onClick = showTagTextField
@@ -117,6 +118,7 @@ fun TagTextField(
             )
             HarooButton(
                 alpha = 0f,
+                border = null,
                 onClick = onAddTagAndClearTag
             ) {
                 Icon(

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -2,23 +2,21 @@ package com.feature.post
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.BottomAppBar
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.paging.compose.collectAsLazyPagingItems
-import com.core.designsystem.components.*
+import com.core.designsystem.components.BackAndRightButtonHeader
+import com.core.designsystem.components.HarooBottomDrawer
+import com.core.designsystem.components.HarooTextField
+import com.core.designsystem.components.RemovableImage
 import com.core.designsystem.modifiers.onInteraction
 import com.core.designsystem.theme.HarooTheme
 import com.core.ui.date.YearMonthDayText
@@ -28,85 +26,66 @@ import com.core.ui.image.AsyncImageLazyRow
 import com.core.ui.tag.TagContainer
 import java.time.LocalDate
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun PostScreen(
-    postViewModel: PostViewModel = hiltViewModel(),
-    focusManager: FocusManager = LocalFocusManager.current,
-    isImeVisible: Boolean = WindowInsets.isImeVisible
+    postViewModel: PostViewModel = hiltViewModel()
 ) {
-    LaunchedEffect(Unit) {
-        postViewModel.getPost(2023, 4, 13)
-    }
-    val images = postViewModel.images.collectAsLazyPagingItems()
-    val selectedImages = postViewModel.selectedImages.collectAsState()
-    val tags = postViewModel.tags.collectAsState()
-    val bottomDrawerState = rememberHarooBottomDrawerState()
-    val content = postViewModel.content.collectAsState()
+    val postStateHolder = rememberPostScreenState(postViewModel = postViewModel)
+    PostScreen(postStateHolder = postStateHolder)
+}
 
-    BackHandler(enabled = bottomDrawerState.isShow.value) {
-        bottomDrawerState.hide()
+@Composable
+fun PostScreen(
+    postStateHolder: PostScreenStateHolder
+) {
+    // BottomDrawer 가 열려 있다면 Back 버튼 클릭 시, Drawer hide
+    BackHandler(enabled = postStateHolder.isBottomDrawer.value) {
+        postStateHolder.bottomDrawerHide()
     }
 
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPress = interactionSource.collectIsPressedAsState()
-    val showTagTextField = remember { mutableStateOf(false) }
-
-    LaunchedEffect(key1 = isPress.value) {
-        // 1. A, B 클릭 시
-        if (isPress.value) {
-            // 2. C, D focus lost
-            focusManager.clearFocus()
-            // 3. D close
-            if (showTagTextField.value)
-                showTagTextField.value = false
-        }
-    }
-    LaunchedEffect(key1 = isImeVisible) {
-        if (isImeVisible.not() && showTagTextField.value) {
-            showTagTextField.value = false
-        }
-    }
+    postStateHolder.CollectImeVisible()
+    postStateHolder.CollectPressFlag()
 
     HarooBottomDrawer(
         modifier = Modifier
             .statusBarsPadding()
             .navigationBarsPadding()
             .imePadding(),
-        drawerState = bottomDrawerState,
+        drawerState = postStateHolder.bottomDrawerState,
         drawerContent = {
             DrawerGalleryContainer(
-                images = images,
-                selectedImages = selectedImages.value,
+                images = postStateHolder.images,
+                selectedImages = postStateHolder.selectedImages,
                 limit = PostViewModel.IMAGE_SELECT_LIMIT,
                 space = 2.dp,
-                onClose = { bottomDrawerState.hide() },
-                onImageSelect = {
-                    postViewModel.setImages(it)
-                    bottomDrawerState.hide()
-                }
+                onClose = postStateHolder::bottomDrawerHide,
+                onImageSelect = postStateHolder::addSelectedImage
             )
         }
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground))
+                .background(
+                    Brush.linearGradient(
+                        HarooTheme.colors.interactiveBackground
+                    )
+                )
         ) {
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .onInteraction(interactionSource)
+                    .onInteraction(postStateHolder.interactionSource)
                     .onFocusChanged {
                         // 4. C 클릭 시, D가 열려 있는 경우 close
-                        if (it.isFocused && showTagTextField.value)
-                            showTagTextField.value = false
+                        if (it.isFocused)
+                            postStateHolder.closeTagTextField()
                     }
             ) {
                 BackAndRightButtonHeader(
                     title = "글 작성",
                     onBackPressed = { },
-                    onClick = postViewModel::savePost
+                    onClick = postStateHolder::savePost
                 ) {
                     // TODO 새 글 작성 시에는 저장, 기존 글인 경우 수정정
                     Text(text = "저장")
@@ -120,14 +99,14 @@ fun PostScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(210.dp),
-                    images = selectedImages.value,
+                    images = postStateHolder.selectedImages,
                     space = 4.dp,
                     contentPadding = 12.dp,
                     content = { image ->
                         RemovableImage(
                             image = image,
                             contentScale = ContentScale.FillHeight,
-                            onRemove = postViewModel::removeImage
+                            onRemove = postStateHolder::removeImage
                         )
                     }
                 )
@@ -135,8 +114,8 @@ fun PostScreen(
                     modifier = Modifier.padding(
                         horizontal = 12.dp, vertical = 8.dp
                     ),
-                    value = content.value,
-                    onValueChange = postViewModel::setContent,
+                    value = postStateHolder.content,
+                    onValueChange = postStateHolder::setContent,
                     autoFocus = true,
                     alpha = 0.1f,
                     placeHolder = "내용을 입력해주세요...",
@@ -146,11 +125,11 @@ fun PostScreen(
             }
             TagContainer(
                 modifier = Modifier.padding(horizontal = 12.dp),
-                showTagTextFieldFlag = showTagTextField.value,
-                tags = tags.value,
-                onAddTag = postViewModel::addTag,
-                onRemoveTag = postViewModel::removeTag,
-                showTagTextField = { showTagTextField.value = true }
+                showTagTextFieldFlag = postStateHolder.showTagTextFieldFlag,
+                tags = postStateHolder.tags,
+                onAddTag = postStateHolder::addTag,
+                onRemoveTag = postStateHolder::removeTag,
+                showTagTextField = postStateHolder::showTagTextField
             )
             BottomAppBar(
                 modifier = Modifier
@@ -158,20 +137,12 @@ fun PostScreen(
                 backgroundColor = Color.Transparent
             ) {
                 GalleryListContainer(
-                    images = images,
+                    images = postStateHolder.images,
                     space = 8.dp,
-                    selectedImages = selectedImages.value,
+                    selectedImages = postStateHolder.selectedImages,
                     limit = PostViewModel.IMAGE_SELECT_LIMIT,
-                    onClickAddButton = {
-                        if (showTagTextField.value) showTagTextField.value = false
-                        focusManager.clearFocus()
-                        bottomDrawerState.show()
-                    },
-                    onImageSelect = {
-                        if (showTagTextField.value) showTagTextField.value = false
-                        focusManager.clearFocus()
-                        postViewModel.selectImage(it)
-                    }
+                    onClickAddButton = postStateHolder::showBottomDrawer,
+                    onImageSelect = postStateHolder::setSelectedImage
                 )
             }
         }

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.core.designsystem.components.BackAndRightButtonHeader
 import com.core.designsystem.components.HarooBottomDrawer
@@ -19,11 +18,13 @@ import com.core.designsystem.components.HarooTextField
 import com.core.designsystem.components.RemovableImage
 import com.core.designsystem.modifiers.onInteraction
 import com.core.designsystem.theme.HarooTheme
+import com.core.designsystem.util.getString
 import com.core.ui.date.YearMonthDayText
 import com.core.ui.gallery.DrawerGalleryContainer
 import com.core.ui.gallery.GalleryListContainer
 import com.core.ui.image.AsyncImageLazyRow
 import com.core.ui.tag.TagContainer
+import com.feature.post.ui.Dimens
 
 @Composable
 fun PostScreen(
@@ -56,7 +57,7 @@ fun PostScreen(
                 images = postStateHolder.images,
                 selectedImages = postStateHolder.selectedImages,
                 limit = PostViewModel.IMAGE_SELECT_LIMIT,
-                space = 2.dp,
+                space = Dimens.galleryContainerSpace,
                 onClose = postStateHolder::bottomDrawerHide,
                 onImageSelect = postStateHolder::addSelectedImage
             )
@@ -108,7 +109,7 @@ fun PostScreenHeader(
         onClick = postStateHolder::savePost
     ) {
         // TODO 새 글 작성 시에는 저장, 기존 글인 경우 수정정
-        Text(text = "저장")
+        Text(text = getString(id = R.string.save_btn))
     }
 }
 
@@ -121,17 +122,17 @@ fun PostContent(
 ) {
     // 날짜
     YearMonthDayText(
-        modifier = Modifier.padding(top = 26.dp, start = 16.dp),
+        modifier = Modifier.padding(Dimens.datePadding),
         date = postStateHolder.date
     )
     // 사용자 가 선택한 이미지 리스트
     AsyncImageLazyRow(
         modifier = Modifier
             .fillMaxWidth()
-            .height(210.dp),
+            .height(Dimens.selectedImageListHeight),
         images = postStateHolder.selectedImages,
-        space = 4.dp,
-        contentPadding = 12.dp,
+        space = Dimens.selectedImageListSpace,
+        contentPadding = Dimens.selectedImageListPadding,
         content = { image ->
             RemovableImage(
                 image = image,
@@ -142,16 +143,14 @@ fun PostContent(
     )
     // 게시글 의 내용을 입력 하는 TextField
     HarooTextField(
-        modifier = Modifier.padding(
-            horizontal = 12.dp, vertical = 8.dp
-        ),
+        modifier = Modifier.padding(Dimens.contentPadding),
         value = postStateHolder.content,
         onValueChange = postStateHolder::setContent,
         autoFocus = true,
-        alpha = 0.1f,
-        placeHolder = "내용을 입력해주세요...",
+        alpha = Dimens.contentAlpha,
+        placeHolder = getString(id = R.string.content_hint),
         singleLine = false,
-        contentPadding = PaddingValues(16.dp)
+        contentPadding = Dimens.contentInnerPadding
     )
 }
 
@@ -163,7 +162,7 @@ fun PostScreenBottomAppBar(
     postStateHolder: PostScreenStateHolder
 ) {
     TagContainer(
-        modifier = Modifier.padding(horizontal = 12.dp),
+        modifier = Modifier.padding(Dimens.tagPadding),
         showTagTextFieldFlag = postStateHolder.showTagTextFieldFlag,
         tags = postStateHolder.tags,
         onAddTag = postStateHolder::addTag,
@@ -172,12 +171,12 @@ fun PostScreenBottomAppBar(
     )
     BottomAppBar(
         modifier = Modifier
-            .padding(vertical = 12.dp),
+            .padding(Dimens.bottomAppBarPadding),
         backgroundColor = Color.Transparent
     ) {
         GalleryListContainer(
             images = postStateHolder.images,
-            space = 8.dp,
+            space = Dimens.galleryListContainerSpace,
             selectedImages = postStateHolder.selectedImages,
             limit = PostViewModel.IMAGE_SELECT_LIMIT,
             onClickAddButton = postStateHolder::showBottomDrawer,

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -84,6 +84,7 @@ fun PostScreen(
                 onBaseClick = postStateHolder::onBaseBtnClick,
                 onBackPressed = postStateHolder::onBackPressed,
                 postType = postStateHolder.postType,
+                isEditMode = postStateHolder.editable,
                 date = postStateHolder.date,
                 selectedImages = postStateHolder.selectedImages,
                 onRemoveSelectedImage = postStateHolder::removeImage,
@@ -91,6 +92,7 @@ fun PostScreen(
                 setContent = postStateHolder::setContent
             )
             PostScreenBottomAppBar(
+                isEditMode = postStateHolder.editable,
                 showTagTextFieldFlag = postStateHolder.showTagTextFieldFlag,
                 tags = postStateHolder.tags,
                 images = postStateHolder.images,
@@ -115,6 +117,7 @@ fun ColumnScope.PostBody(
     onBaseClick: () -> Unit,
     onBackPressed: () -> Unit,
     postType: PostType,
+    isEditMode: Boolean,
     date: LocalDate,
     selectedImages: List<ImageUiModel>,
     onRemoveSelectedImage: (ImageUiModel) -> Unit,
@@ -137,6 +140,7 @@ fun ColumnScope.PostBody(
         )
         PostContent(
             date = date,
+            isEditMode = isEditMode,
             selectedImages = selectedImages,
             onRemoveSelectedImage = onRemoveSelectedImage,
             content = content,
@@ -209,6 +213,7 @@ fun PostScreenHeader(
 @Composable
 fun PostContent(
     date: LocalDate,
+    isEditMode: Boolean,
     selectedImages: List<ImageUiModel>,
     onRemoveSelectedImage: (ImageUiModel) -> Unit,
     content: String,
@@ -230,6 +235,7 @@ fun PostContent(
         content = { image ->
             RemovableImage(
                 image = image,
+                isEditMode = { isEditMode },
                 contentScale = ContentScale.FillHeight,
                 onRemove = onRemoveSelectedImage
             )
@@ -240,7 +246,8 @@ fun PostContent(
         modifier = Modifier.padding(Dimens.contentPadding),
         value = content,
         onValueChange = setContent,
-        autoFocus = true,
+        autoFocus = false,
+        enabled = isEditMode,
         alpha = Dimens.contentAlpha,
         placeHolder = getString(id = R.string.content_hint),
         singleLine = false,
@@ -253,6 +260,7 @@ fun PostContent(
  */
 @Composable
 fun PostScreenBottomAppBar(
+    isEditMode: Boolean,
     showTagTextFieldFlag: Boolean,
     tags: List<TagUiModel>,
     images: LazyPagingItems<ImageUiModel>,
@@ -265,24 +273,28 @@ fun PostScreenBottomAppBar(
 ) {
     TagContainer(
         modifier = Modifier.padding(Dimens.tagPadding),
+        isEditMode = isEditMode,
         showTagTextFieldFlag = showTagTextFieldFlag,
         tags = tags,
         onAddTag = onAddTags,
         onRemoveTag = onRemoveTag,
         showTagTextField = showTagTextField
     )
-    BottomAppBar(
-        modifier = Modifier
-            .padding(Dimens.bottomAppBarPadding),
-        backgroundColor = Color.Transparent
-    ) {
-        GalleryListContainer(
-            images = images,
-            space = Dimens.galleryListContainerSpace,
-            selectedImages = selectedImages,
-            limit = PostViewModel.IMAGE_SELECT_LIMIT,
-            onClickAddButton = showBottomDrawer,
-            onImageSelect = onImageSelect
-        )
+
+    if (isEditMode) {
+        BottomAppBar(
+            modifier = Modifier
+                .padding(Dimens.bottomAppBarPadding),
+            backgroundColor = Color.Transparent
+        ) {
+            GalleryListContainer(
+                images = images,
+                space = Dimens.galleryListContainerSpace,
+                selectedImages = selectedImages,
+                limit = PostViewModel.IMAGE_SELECT_LIMIT,
+                onClickAddButton = showBottomDrawer,
+                onImageSelect = onImageSelect
+            )
+        }
     }
 }

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -103,7 +103,7 @@ fun PostScreen(
                 BackAndRightButtonHeader(
                     title = "글 작성",
                     onBackPressed = { },
-                    onClick = { }
+                    onClick = postViewModel::savePost
                 ) {
                     // TODO 새 글 작성 시에는 저장, 기존 글인 경우 수정정
                     Text(text = "저장")

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -28,9 +28,10 @@ import com.feature.post.ui.Dimens
 
 @Composable
 fun PostScreen(
+    year: Int, month: Int, day: Int,
     postViewModel: PostViewModel = hiltViewModel()
 ) {
-    val postStateHolder = rememberPostScreenState(postViewModel = postViewModel)
+    val postStateHolder = rememberPostScreenState(year, month, day, postViewModel = postViewModel)
     PostScreen(postStateHolder = postStateHolder)
 }
 

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -24,7 +24,6 @@ import com.core.ui.gallery.DrawerGalleryContainer
 import com.core.ui.gallery.GalleryListContainer
 import com.core.ui.image.AsyncImageLazyRow
 import com.core.ui.tag.TagContainer
-import java.time.LocalDate
 
 @Composable
 fun PostScreen(
@@ -66,86 +65,123 @@ fun PostScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(
-                    Brush.linearGradient(
-                        HarooTheme.colors.interactiveBackground
-                    )
-                )
+                .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground))
         ) {
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .onInteraction(postStateHolder.interactionSource)
-                    .onFocusChanged {
-                        // 4. C 클릭 시, D가 열려 있는 경우 close
-                        if (it.isFocused)
-                            postStateHolder.closeTagTextField()
-                    }
-            ) {
-                BackAndRightButtonHeader(
-                    title = "글 작성",
-                    onBackPressed = { },
-                    onClick = postStateHolder::savePost
-                ) {
-                    // TODO 새 글 작성 시에는 저장, 기존 글인 경우 수정정
-                    Text(text = "저장")
-                }
-                YearMonthDayText(
-                    modifier = Modifier
-                        .padding(top = 26.dp, start = 16.dp),
-                    date = LocalDate.now()
-                )
-                AsyncImageLazyRow(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(210.dp),
-                    images = postStateHolder.selectedImages,
-                    space = 4.dp,
-                    contentPadding = 12.dp,
-                    content = { image ->
-                        RemovableImage(
-                            image = image,
-                            contentScale = ContentScale.FillHeight,
-                            onRemove = postStateHolder::removeImage
-                        )
-                    }
-                )
-                HarooTextField(
-                    modifier = Modifier.padding(
-                        horizontal = 12.dp, vertical = 8.dp
-                    ),
-                    value = postStateHolder.content,
-                    onValueChange = postStateHolder::setContent,
-                    autoFocus = true,
-                    alpha = 0.1f,
-                    placeHolder = "내용을 입력해주세요...",
-                    singleLine = false,
-                    contentPadding = PaddingValues(16.dp)
-                )
-            }
-            TagContainer(
-                modifier = Modifier.padding(horizontal = 12.dp),
-                showTagTextFieldFlag = postStateHolder.showTagTextFieldFlag,
-                tags = postStateHolder.tags,
-                onAddTag = postStateHolder::addTag,
-                onRemoveTag = postStateHolder::removeTag,
-                showTagTextField = postStateHolder::showTagTextField
-            )
-            BottomAppBar(
-                modifier = Modifier
-                    .padding(vertical = 12.dp),
-                backgroundColor = Color.Transparent
-            ) {
-                GalleryListContainer(
-                    images = postStateHolder.images,
-                    space = 8.dp,
-                    selectedImages = postStateHolder.selectedImages,
-                    limit = PostViewModel.IMAGE_SELECT_LIMIT,
-                    onClickAddButton = postStateHolder::showBottomDrawer,
-                    onImageSelect = postStateHolder::setSelectedImage
-                )
-            }
+            PostBody(postStateHolder = postStateHolder)
+            PostScreenBottomAppBar(postStateHolder = postStateHolder)
         }
     }
 }
-//}
+
+/**
+ * PostScreen 의 header / body / bottom 중 header 와 body
+ */
+@Composable
+fun ColumnScope.PostBody(
+    postStateHolder: PostScreenStateHolder
+) {
+    Column(
+        modifier = Modifier
+            .weight(1f)
+            .onInteraction(postStateHolder.interactionSource)
+            .onFocusChanged {
+                // 4. C 클릭 시, D가 열려 있는 경우 close
+                if (it.isFocused)
+                    postStateHolder.closeTagTextField()
+            }
+    ) {
+        PostScreenHeader(postStateHolder = postStateHolder)
+        PostContent(postStateHolder = postStateHolder)
+    }
+}
+
+/**
+ * PostScreen 의 header / body / bottom 중 header
+ */
+@Composable
+fun PostScreenHeader(
+    postStateHolder: PostScreenStateHolder
+) {
+    BackAndRightButtonHeader(
+        title = "글 작성",
+        onBackPressed = { },
+        onClick = postStateHolder::savePost
+    ) {
+        // TODO 새 글 작성 시에는 저장, 기존 글인 경우 수정정
+        Text(text = "저장")
+    }
+}
+
+/**
+ * PostScreen 의 header / body / bottom 중 body
+ */
+@Composable
+fun PostContent(
+    postStateHolder: PostScreenStateHolder
+) {
+    // 날짜
+    YearMonthDayText(
+        modifier = Modifier.padding(top = 26.dp, start = 16.dp),
+        date = postStateHolder.date
+    )
+    // 사용자 가 선택한 이미지 리스트
+    AsyncImageLazyRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(210.dp),
+        images = postStateHolder.selectedImages,
+        space = 4.dp,
+        contentPadding = 12.dp,
+        content = { image ->
+            RemovableImage(
+                image = image,
+                contentScale = ContentScale.FillHeight,
+                onRemove = postStateHolder::removeImage
+            )
+        }
+    )
+    // 게시글 의 내용을 입력 하는 TextField
+    HarooTextField(
+        modifier = Modifier.padding(
+            horizontal = 12.dp, vertical = 8.dp
+        ),
+        value = postStateHolder.content,
+        onValueChange = postStateHolder::setContent,
+        autoFocus = true,
+        alpha = 0.1f,
+        placeHolder = "내용을 입력해주세요...",
+        singleLine = false,
+        contentPadding = PaddingValues(16.dp)
+    )
+}
+
+/**
+ * PostScreen 의 header / body / bottom 중 bottom
+ */
+@Composable
+fun PostScreenBottomAppBar(
+    postStateHolder: PostScreenStateHolder
+) {
+    TagContainer(
+        modifier = Modifier.padding(horizontal = 12.dp),
+        showTagTextFieldFlag = postStateHolder.showTagTextFieldFlag,
+        tags = postStateHolder.tags,
+        onAddTag = postStateHolder::addTag,
+        onRemoveTag = postStateHolder::removeTag,
+        showTagTextField = postStateHolder::showTagTextField
+    )
+    BottomAppBar(
+        modifier = Modifier
+            .padding(vertical = 12.dp),
+        backgroundColor = Color.Transparent
+    ) {
+        GalleryListContainer(
+            images = postStateHolder.images,
+            space = 8.dp,
+            selectedImages = postStateHolder.selectedImages,
+            limit = PostViewModel.IMAGE_SELECT_LIMIT,
+            onClickAddButton = postStateHolder::showBottomDrawer,
+            onImageSelect = postStateHolder::setSelectedImage
+        )
+    }
+}

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -292,7 +292,9 @@ fun PostScreenBottomAppBar(
         showTagTextField = showTagTextField
     )
 
-    if (isEditMode) {
+    if (isEditMode.not()) {
+        Spacer(modifier = Modifier.height(Dimens.spaceBetweenTagAndGalleryList))
+    } else {
         BottomAppBar(
             modifier = Modifier
                 .padding(Dimens.bottomAppBarPadding),

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
@@ -41,6 +42,18 @@ fun PostScreen(
 ) {
     val postStateHolder =
         rememberPostScreenState(year, month, day, postViewModel = postViewModel, onBackPressed = {})
+
+    LaunchedEffect(Unit) {
+        postViewModel.postUiEvent.collect {
+            when (it) {
+                PostUiEvent.Initialized -> postViewModel.getPost(year, month, day)
+                PostUiEvent.EndLoadInitDate -> {}
+                PostUiEvent.FailSaveOrEditPost -> {}
+                PostUiEvent.SuccessSaveOrEditPost -> {}
+            }
+        }
+    }
+
     PostScreen(postStateHolder = postStateHolder)
 }
 
@@ -60,7 +73,8 @@ fun PostScreen(
         modifier = Modifier
             .statusBarsPadding()
             .navigationBarsPadding()
-            .imePadding(),
+            .imePadding()
+            .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground)),
         drawerState = postStateHolder.bottomDrawerState,
         drawerContent = {
             DrawerGalleryContainer(
@@ -74,9 +88,7 @@ fun PostScreen(
         }
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground))
+            modifier = Modifier.fillMaxSize()
         ) {
             PostBody(
                 interactionSource = postStateHolder.interactionSource,
@@ -246,7 +258,6 @@ fun PostContent(
         modifier = Modifier.padding(Dimens.contentPadding),
         value = content,
         onValueChange = setContent,
-        autoFocus = false,
         enabled = isEditMode,
         alpha = Dimens.contentAlpha,
         placeHolder = getString(id = R.string.content_hint),

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -35,6 +35,9 @@ fun PostScreen(
     focusManager: FocusManager = LocalFocusManager.current,
     isImeVisible: Boolean = WindowInsets.isImeVisible
 ) {
+    LaunchedEffect(Unit) {
+        postViewModel.getPost(2023, 4, 13)
+    }
     val images = postViewModel.images.collectAsLazyPagingItems()
     val selectedImages = postViewModel.selectedImages.collectAsState()
     val tags = postViewModel.tags.collectAsState()

--- a/feature/post/src/main/java/com/feature/post/PostUiState.kt
+++ b/feature/post/src/main/java/com/feature/post/PostUiState.kt
@@ -100,6 +100,8 @@ class PostScreenStateHolder(
             isPostFlag.value -> PostType.SHOW
             else -> PostType.NEW
         }
+    val editable: Boolean
+        get() = postType != PostType.SHOW
 
     @Composable
     fun CollectImeVisible() {

--- a/feature/post/src/main/java/com/feature/post/PostUiState.kt
+++ b/feature/post/src/main/java/com/feature/post/PostUiState.kt
@@ -17,13 +17,11 @@ import com.core.model.feature.TagUiModel
 import java.time.LocalDate
 
 @Composable
-@OptIn(ExperimentalLayoutApi::class)
 fun rememberPostScreenState(
     year: Int, month: Int, day: Int,
     postViewModel: PostViewModel,
     bottomDrawerState: HarooBottomDrawerState = rememberHarooBottomDrawerState(),
     focusManager: FocusManager = LocalFocusManager.current,
-    isImeVisible: Boolean = WindowInsets.isImeVisible,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     onBackPressed: () -> Unit
 ): PostScreenStateHolder {
@@ -46,7 +44,6 @@ fun rememberPostScreenState(
             _content = content,
             bottomDrawerState = bottomDrawerState,
             focusManager = focusManager,
-            isImeVisible = isImeVisible,
             interactionSource = interactionSource,
             pressFlag = pressFlag,
             postId = postId,
@@ -68,7 +65,6 @@ class PostScreenStateHolder(
     private val _content: State<String>,
     val bottomDrawerState: HarooBottomDrawerState,
     val focusManager: FocusManager,
-    val isImeVisible: Boolean,
     val interactionSource: MutableInteractionSource,
     val pressFlag: State<Boolean>,
     val postId: State<Long?>,
@@ -99,7 +95,10 @@ class PostScreenStateHolder(
         get() = postType != PostType.SHOW
 
     @Composable
-    fun CollectImeVisible() {
+    @OptIn(ExperimentalLayoutApi::class)
+    fun CollectImeVisible(
+        isImeVisible: Boolean = WindowInsets.isImeVisible
+    ) {
         LaunchedEffect(key1 = isImeVisible) {
             if (isImeVisible.not() && _showTagTextFieldFlag.value) {
                 _showTagTextFieldFlag.value = false

--- a/feature/post/src/main/java/com/feature/post/PostUiState.kt
+++ b/feature/post/src/main/java/com/feature/post/PostUiState.kt
@@ -1,0 +1,147 @@
+package com.feature.post
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.runtime.*
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.core.designsystem.components.HarooBottomDrawerState
+import com.core.designsystem.components.rememberHarooBottomDrawerState
+import com.core.model.feature.ImageUiModel
+import com.core.model.feature.TagUiModel
+
+@Composable
+@OptIn(ExperimentalLayoutApi::class)
+fun rememberPostScreenState(
+    postViewModel: PostViewModel,
+    bottomDrawerState: HarooBottomDrawerState = rememberHarooBottomDrawerState(),
+    focusManager: FocusManager = LocalFocusManager.current,
+    isImeVisible: Boolean = WindowInsets.isImeVisible,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+): PostScreenStateHolder {
+    val images = postViewModel.images.collectAsLazyPagingItems()
+    val selectedImages = postViewModel.selectedImages.collectAsState()
+    val tags = postViewModel.tags.collectAsState()
+    val content = postViewModel.content.collectAsState()
+    val pressFlag = interactionSource.collectIsPressedAsState()
+    return remember(postViewModel, bottomDrawerState) {
+        PostScreenStateHolder(
+            postViewModel = postViewModel,
+            images = images,
+            _selectedImages = selectedImages,
+            _tags = tags,
+            _content = content,
+            bottomDrawerState = bottomDrawerState,
+            focusManager = focusManager,
+            isImeVisible = isImeVisible,
+            interactionSource = interactionSource,
+            pressFlag = pressFlag,
+            _showTagTextFieldFlag = mutableStateOf(false)
+        )
+    }
+}
+
+class PostScreenStateHolder(
+    private val postViewModel: PostViewModel,
+    val images: LazyPagingItems<ImageUiModel>,
+    private val _selectedImages: State<List<ImageUiModel>>,
+    private val _tags: State<List<TagUiModel>>,
+    private val _content: State<String>,
+    val bottomDrawerState: HarooBottomDrawerState,
+    val focusManager: FocusManager,
+    val isImeVisible: Boolean,
+    val interactionSource: MutableInteractionSource,
+    val pressFlag: State<Boolean>,
+    private val _showTagTextFieldFlag: MutableState<Boolean>
+) {
+    val selectedImages: List<ImageUiModel>
+        get() = _selectedImages.value
+    val tags: List<TagUiModel>
+        get() = _tags.value
+    val content: String
+        get() = _content.value
+    val showTagTextFieldFlag: Boolean
+        get() = _showTagTextFieldFlag.value
+
+    val isBottomDrawer: State<Boolean>
+        get() = bottomDrawerState.isShow
+
+    @Composable
+    fun CollectImeVisible() {
+        LaunchedEffect(key1 = isImeVisible) {
+            if (isImeVisible.not() && _showTagTextFieldFlag.value) {
+                _showTagTextFieldFlag.value = false
+            }
+        }
+    }
+
+    @Composable
+    fun CollectPressFlag() {
+        LaunchedEffect(key1 = pressFlag.value) {
+            // 1. A, B 클릭 시
+            if (pressFlag.value) {
+                // 2. C, D focus lost
+                clearFocus()
+            }
+        }
+    }
+
+    fun showBottomDrawer() {
+        clearFocus()
+        bottomDrawerState.show()
+    }
+
+    fun bottomDrawerHide() {
+        bottomDrawerState.hide()
+    }
+
+    private fun clearFocus() {
+        focusManager.clearFocus()
+        closeTagTextField()
+    }
+
+    fun closeTagTextField() {
+        if (_showTagTextFieldFlag.value) {
+            _showTagTextFieldFlag.value = false
+        }
+    }
+
+    fun addSelectedImage(images: List<ImageUiModel>) {
+        postViewModel.setImages(images)
+        bottomDrawerHide()
+    }
+
+    fun setSelectedImage(imageUiModel: ImageUiModel) {
+        clearFocus()
+        postViewModel.selectImage(imageUiModel)
+    }
+
+    fun removeImage(imageUiModel: ImageUiModel) {
+        postViewModel.removeImage(imageUiModel)
+    }
+
+    fun setContent(content: String) {
+        postViewModel.setContent(content)
+    }
+
+    fun addTag(tag: String) {
+        postViewModel.addTag(tag)
+    }
+
+    fun removeTag(tagUiModel: TagUiModel) {
+        postViewModel.removeTag(tagUiModel)
+    }
+
+    fun showTagTextField() {
+        _showTagTextFieldFlag.value = true
+    }
+
+    fun savePost() {
+        postViewModel.savePost()
+    }
+}

--- a/feature/post/src/main/java/com/feature/post/PostUiState.kt
+++ b/feature/post/src/main/java/com/feature/post/PostUiState.kt
@@ -36,11 +36,6 @@ fun rememberPostScreenState(
     val isPostFlag = postViewModel.isPostFlag.collectAsState()
     val isEditMode = postViewModel.isEditMode.collectAsState()
 
-    LaunchedEffect(year, month, day) {
-        if (isPostFlag.value.not())
-            postViewModel.getPost(year, month, day)
-    }
-
     return remember(year, month, day, postViewModel, bottomDrawerState) {
         PostScreenStateHolder(
             year, month, day,

--- a/feature/post/src/main/java/com/feature/post/PostUiState.kt
+++ b/feature/post/src/main/java/com/feature/post/PostUiState.kt
@@ -184,7 +184,10 @@ class PostScreenStateHolder(
      */
     fun onBackPressed() {
         when (postType) {
-            PostType.EDIT -> postViewModel.toggleEditMode()
+            PostType.EDIT -> {
+                postViewModel.getPost(year,month,day)
+                postViewModel.toggleEditMode()
+            }
             PostType.NEW,
             PostType.SHOW -> _onBackPressed()
         }

--- a/feature/post/src/main/java/com/feature/post/PostUiState.kt
+++ b/feature/post/src/main/java/com/feature/post/PostUiState.kt
@@ -33,7 +33,7 @@ fun rememberPostScreenState(
     val content = postViewModel.content.collectAsState()
     val pressFlag = interactionSource.collectIsPressedAsState()
 
-    val isPostFlag = postViewModel.isPostFlag.collectAsState()
+    val postId = postViewModel.postId.collectAsState()
     val isEditMode = postViewModel.isEditMode.collectAsState()
 
     return remember(year, month, day, postViewModel, bottomDrawerState) {
@@ -49,7 +49,7 @@ fun rememberPostScreenState(
             isImeVisible = isImeVisible,
             interactionSource = interactionSource,
             pressFlag = pressFlag,
-            isPostFlag = isPostFlag,
+            postId = postId,
             isEditMode = isEditMode,
             _showTagTextFieldFlag = mutableStateOf(false),
             _onBackPressed = onBackPressed
@@ -71,7 +71,7 @@ class PostScreenStateHolder(
     val isImeVisible: Boolean,
     val interactionSource: MutableInteractionSource,
     val pressFlag: State<Boolean>,
-    val isPostFlag: State<Boolean>,
+    val postId: State<Long?>,
     val isEditMode: State<Boolean>,
     private val _showTagTextFieldFlag: MutableState<Boolean>,
     private val _onBackPressed: () -> Unit
@@ -91,8 +91,8 @@ class PostScreenStateHolder(
         get() = bottomDrawerState.isShow
     val postType: PostType
         get() = when {
-            isPostFlag.value && isEditMode.value -> PostType.EDIT
-            isPostFlag.value -> PostType.SHOW
+            postId.value != null && isEditMode.value -> PostType.EDIT
+            postId.value != null -> PostType.SHOW
             else -> PostType.NEW
         }
     val editable: Boolean
@@ -175,7 +175,7 @@ class PostScreenStateHolder(
         when (postType) {
             PostType.SHOW -> postViewModel.toggleEditMode()
             PostType.NEW,
-            PostType.EDIT -> postViewModel.savePost()
+            PostType.EDIT -> postViewModel.savePost(year, month, day)
         }
     }
 
@@ -185,7 +185,7 @@ class PostScreenStateHolder(
     fun onBackPressed() {
         when (postType) {
             PostType.EDIT -> {
-                postViewModel.getPost(year,month,day)
+                postViewModel.getPost(year, month, day)
                 postViewModel.toggleEditMode()
             }
             PostType.NEW,

--- a/feature/post/src/main/java/com/feature/post/PostUiState.kt
+++ b/feature/post/src/main/java/com/feature/post/PostUiState.kt
@@ -14,10 +14,12 @@ import com.core.designsystem.components.HarooBottomDrawerState
 import com.core.designsystem.components.rememberHarooBottomDrawerState
 import com.core.model.feature.ImageUiModel
 import com.core.model.feature.TagUiModel
+import java.time.LocalDate
 
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
 fun rememberPostScreenState(
+    date: LocalDate = LocalDate.now(),
     postViewModel: PostViewModel,
     bottomDrawerState: HarooBottomDrawerState = rememberHarooBottomDrawerState(),
     focusManager: FocusManager = LocalFocusManager.current,
@@ -31,6 +33,7 @@ fun rememberPostScreenState(
     val pressFlag = interactionSource.collectIsPressedAsState()
     return remember(postViewModel, bottomDrawerState) {
         PostScreenStateHolder(
+            date = date,
             postViewModel = postViewModel,
             images = images,
             _selectedImages = selectedImages,
@@ -47,6 +50,7 @@ fun rememberPostScreenState(
 }
 
 class PostScreenStateHolder(
+    val date: LocalDate,
     private val postViewModel: PostViewModel,
     val images: LazyPagingItems<ImageUiModel>,
     private val _selectedImages: State<List<ImageUiModel>>,

--- a/feature/post/src/main/java/com/feature/post/PostUiState.kt
+++ b/feature/post/src/main/java/com/feature/post/PostUiState.kt
@@ -19,21 +19,24 @@ import java.time.LocalDate
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
 fun rememberPostScreenState(
-    date: LocalDate = LocalDate.now(),
+    year: Int, month: Int, day: Int,
     postViewModel: PostViewModel,
     bottomDrawerState: HarooBottomDrawerState = rememberHarooBottomDrawerState(),
     focusManager: FocusManager = LocalFocusManager.current,
     isImeVisible: Boolean = WindowInsets.isImeVisible,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 ): PostScreenStateHolder {
+    LaunchedEffect(year, month, day) {
+        postViewModel.getPost(year, month, day)
+    }
     val images = postViewModel.images.collectAsLazyPagingItems()
     val selectedImages = postViewModel.selectedImages.collectAsState()
     val tags = postViewModel.tags.collectAsState()
     val content = postViewModel.content.collectAsState()
     val pressFlag = interactionSource.collectIsPressedAsState()
-    return remember(postViewModel, bottomDrawerState) {
+    return remember(year, month, day, postViewModel, bottomDrawerState) {
         PostScreenStateHolder(
-            date = date,
+            year, month, day,
             postViewModel = postViewModel,
             images = images,
             _selectedImages = selectedImages,
@@ -50,7 +53,9 @@ fun rememberPostScreenState(
 }
 
 class PostScreenStateHolder(
-    val date: LocalDate,
+    private val year: Int,
+    private val month: Int,
+    private val day: Int,
     private val postViewModel: PostViewModel,
     val images: LazyPagingItems<ImageUiModel>,
     private val _selectedImages: State<List<ImageUiModel>>,
@@ -71,6 +76,8 @@ class PostScreenStateHolder(
         get() = _content.value
     val showTagTextFieldFlag: Boolean
         get() = _showTagTextFieldFlag.value
+    val date: LocalDate
+        get() = LocalDate.of(year, month, day)
 
     val isBottomDrawer: State<Boolean>
         get() = bottomDrawerState.isShow

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -23,6 +23,9 @@ class PostViewModel @Inject constructor(
     private val addPostUseCase: AddPostUseCase,
     private val getPostByDateUseCase: GetPostByDateUseCase
 ) : ViewModel() {
+    private val _postUiEvent = MutableStateFlow<PostUiEvent>(PostUiEvent.Initialized)
+    val postUiEvent: StateFlow<PostUiEvent> = _postUiEvent.asStateFlow()
+
     private val _isPostFlag = MutableStateFlow(false)
     val isPostFlag: StateFlow<Boolean> = _isPostFlag.asStateFlow()
     private val _isEditMode = MutableStateFlow(false)
@@ -54,6 +57,7 @@ class PostViewModel @Inject constructor(
 
                 _isPostFlag.value = post.id != null
             }
+            _postUiEvent.value = PostUiEvent.EndLoadInitDate
         }
     }
 
@@ -118,4 +122,11 @@ class PostViewModel @Inject constructor(
     companion object {
         const val IMAGE_SELECT_LIMIT = 4
     }
+}
+
+sealed interface PostUiEvent {
+    object Initialized : PostUiEvent
+    object EndLoadInitDate : PostUiEvent
+    object SuccessSaveOrEditPost : PostUiEvent
+    object FailSaveOrEditPost : PostUiEvent
 }

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -6,6 +6,7 @@ import androidx.paging.cachedIn
 import androidx.paging.map
 import com.core.domain.post.AddPostUseCase
 import com.core.domain.post.GetImagesUseCase
+import com.core.domain.post.GetPostByDateUseCase
 import com.core.model.domain.Post
 import com.core.model.feature.*
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,7 +20,8 @@ import javax.inject.Inject
 @HiltViewModel
 class PostViewModel @Inject constructor(
     getImagesUseCase: GetImagesUseCase,
-    private val addPostUseCase: AddPostUseCase
+    private val addPostUseCase: AddPostUseCase,
+    private val getPostByDateUseCase: GetPostByDateUseCase
 ) : ViewModel() {
 
     val images = getImagesUseCase()
@@ -35,6 +37,19 @@ class PostViewModel @Inject constructor(
 
     private val _content = MutableStateFlow("")
     val content: StateFlow<String> = _content.asStateFlow()
+
+    /**
+     * 기존 Post 요청
+     */
+    fun getPost(year: Int, month: Int, day: Int) {
+        viewModelScope.launch {
+            getPostByDateUseCase(year, month, day)?.let { post ->
+                _content.value = post.content ?: ""
+                _selectedImages.value = post.images.map { it.toImageUiModel() }
+                _tags.value = post.tags.map { it.toTagUiModel() }
+            }
+        }
+    }
 
     /**
      * 신규 post 저장

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -51,9 +51,9 @@ class PostViewModel @Inject constructor(
                 _content.value = post.content ?: ""
                 _selectedImages.value = post.images.map { it.toImageUiModel() }
                 _tags.value = post.tags.map { it.toTagUiModel() }
-            }
 
-            _isPostFlag.value = true
+                _isPostFlag.value = post.id != null
+            }
         }
     }
 

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -4,20 +4,22 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import androidx.paging.map
+import com.core.domain.post.AddPostUseCase
 import com.core.domain.post.GetImagesUseCase
-import com.core.model.feature.ImageUiModel
-import com.core.model.feature.TagUiModel
-import com.core.model.feature.toImageUiModel
+import com.core.model.domain.Post
+import com.core.model.feature.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class PostViewModel @Inject constructor(
-    getImagesUseCase: GetImagesUseCase
+    getImagesUseCase: GetImagesUseCase,
+    private val addPostUseCase: AddPostUseCase
 ) : ViewModel() {
 
     val images = getImagesUseCase()
@@ -33,6 +35,28 @@ class PostViewModel @Inject constructor(
 
     private val _content = MutableStateFlow("")
     val content: StateFlow<String> = _content.asStateFlow()
+
+    /**
+     * 신규 post 저장
+     */
+    fun savePost() {
+        // 유효성 검사 1. 내용
+        if (_content.value.isBlank()) return
+        // 유효성 검사 2. 이미지 1개 이상
+        if (_selectedImages.value.isEmpty()) return
+
+        viewModelScope.launch {
+            addPostUseCase(
+                Post(
+                    id = null,
+                    year = 2023, month = 4, day = 13,
+                    content = _content.value,
+                    images = _selectedImages.value.map { it.toImage() },
+                    tags = _tags.value.map { it.toTag() }
+                )
+            )
+        }
+    }
 
     fun selectImage(imageUiModel: ImageUiModel) {
         if (imageUiModel in _selectedImages.value) {

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -23,6 +23,10 @@ class PostViewModel @Inject constructor(
     private val addPostUseCase: AddPostUseCase,
     private val getPostByDateUseCase: GetPostByDateUseCase
 ) : ViewModel() {
+    private val _isPostFlag = MutableStateFlow(false)
+    val isPostFlag: StateFlow<Boolean> = _isPostFlag.asStateFlow()
+    private val _isEditMode = MutableStateFlow(false)
+    val isEditMode: StateFlow<Boolean> = _isEditMode.asStateFlow()
 
     val images = getImagesUseCase()
         .map { images ->
@@ -48,6 +52,8 @@ class PostViewModel @Inject constructor(
                 _selectedImages.value = post.images.map { it.toImageUiModel() }
                 _tags.value = post.tags.map { it.toTagUiModel() }
             }
+
+            _isPostFlag.value = true
         }
     }
 
@@ -103,6 +109,10 @@ class PostViewModel @Inject constructor(
 
     fun setContent(content: String) {
         _content.value = content
+    }
+
+    fun toggleEditMode() {
+        _isEditMode.value = _isEditMode.value.not()
     }
 
     companion object {

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import androidx.paging.map
 import com.core.domain.post.GetImagesUseCase
-import com.core.model.domain.toImageUiModel
 import com.core.model.feature.ImageUiModel
 import com.core.model.feature.TagUiModel
+import com.core.model.feature.toImageUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/feature/post/src/main/java/com/feature/post/ui/dimens.kt
+++ b/feature/post/src/main/java/com/feature/post/ui/dimens.kt
@@ -1,0 +1,20 @@
+package com.feature.post.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.dp
+
+internal object Dimens {
+    val galleryContainerSpace = 24.dp
+    val datePadding = PaddingValues(top = 26.dp, start = 16.dp)
+    val selectedImageListHeight = 210.dp
+    val selectedImageListSpace = 4.dp
+    val selectedImageListPadding = 12.dp
+
+    val contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp)
+    const val contentAlpha = 0.1f
+    val contentInnerPadding = PaddingValues(16.dp)
+
+    val tagPadding = PaddingValues(horizontal = 12.dp)
+    val bottomAppBarPadding = PaddingValues(vertical = 12.dp)
+    val galleryListContainerSpace = 8.dp
+}

--- a/feature/post/src/main/java/com/feature/post/ui/dimens.kt
+++ b/feature/post/src/main/java/com/feature/post/ui/dimens.kt
@@ -17,4 +17,7 @@ internal object Dimens {
     val tagPadding = PaddingValues(horizontal = 12.dp)
     val bottomAppBarPadding = PaddingValues(vertical = 12.dp)
     val galleryListContainerSpace = 8.dp
+
+    val headerPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+    val headerExtraBtnPadding = PaddingValues(start = 8.dp)
 }

--- a/feature/post/src/main/java/com/feature/post/ui/dimens.kt
+++ b/feature/post/src/main/java/com/feature/post/ui/dimens.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.dp
 
 internal object Dimens {
-    val galleryContainerSpace = 24.dp
+    val galleryContainerSpace = 2.dp
     val datePadding = PaddingValues(top = 26.dp, start = 16.dp)
     val selectedImageListHeight = 210.dp
     val selectedImageListSpace = 4.dp

--- a/feature/post/src/main/java/com/feature/post/ui/dimens.kt
+++ b/feature/post/src/main/java/com/feature/post/ui/dimens.kt
@@ -7,14 +7,15 @@ internal object Dimens {
     val galleryContainerSpace = 2.dp
     val datePadding = PaddingValues(top = 26.dp, start = 16.dp)
     val selectedImageListHeight = 210.dp
-    val selectedImageListSpace = 4.dp
-    val selectedImageListPadding = 12.dp
+    val selectedImageListSpace = 8.dp
+    val selectedImageListPadding = PaddingValues(top = 12.dp)
 
-    val contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp)
+    val contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp)
     const val contentAlpha = 0.1f
-    val contentInnerPadding = PaddingValues(16.dp)
+    val contentInnerPadding = PaddingValues(12.dp)
 
     val tagPadding = PaddingValues(horizontal = 12.dp)
+    val spaceBetweenTagAndGalleryList = 12.dp
     val bottomAppBarPadding = PaddingValues(vertical = 12.dp)
     val galleryListContainerSpace = 8.dp
 

--- a/feature/post/src/main/res/values/strings.xml
+++ b/feature/post/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="save_btn">저장</string>
+    <string name="edit_btn">수정</string>
+    <string name="del_btn">삭제</string>
+
+    <string name="content_hint">내용을 입력해주세요…</string>
+</resources>

--- a/feature/post/src/main/res/values/strings.xml
+++ b/feature/post/src/main/res/values/strings.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="title_new">새 하루네컷</string>
+    <string name="title_show">하루네컷</string>
+    <string name="title_edit">하루네컷 수정</string>
+
     <string name="save_btn">저장</string>
     <string name="edit_btn">수정</string>
     <string name="del_btn">삭제</string>


### PR DESCRIPTION
#### 📌 내용
PostScreen과 관련된 Business 로직 추가 및 State 관리로직 변경

#### 🛠 Done
- [x] Post 추가 / 수정 / 제거
- [x] 기존 Post 정보 받아오기
- [x] UiState를 한곳에서 관리할 수 있도록 PostStateHolder 추가
- [x] PostScreen의 Component 세분화
- [x] PostType에 따라 Header 변경
- [x] PostType.SHOW 타입인 경우에는 게시글 변경이 불가능하도록 처리

#### 🪴 UI
```
PostType.SHOW 일 떄의 UI
```
<img width="250" src="https://user-images.githubusercontent.com/22411296/231739472-8e1ac9f2-743d-48a1-8e4e-27f8c4b62064.jpeg">

#### 🏠 관련 Issue
Closed #28 