### PR TITLE
[FEAT] #32 HomeScreen에 데이버 바인딩하기

### DIFF
--- a/core/data/src/main/java/com/core/data/post/PostRepository.kt
+++ b/core/data/src/main/java/com/core/data/post/PostRepository.kt
@@ -26,4 +26,7 @@ interface PostRepository {
 
     // 특정 년도/월 post paging 요청
     fun getPostPaging(year: Int, month: Int): Flow<PagingData<PostSources>>
+
+    // 특정 날짜의 게시글 제거
+    suspend fun removePost(postId: Long)
 }

--- a/core/data/src/main/java/com/core/data/post/PostRepository.kt
+++ b/core/data/src/main/java/com/core/data/post/PostRepository.kt
@@ -3,6 +3,7 @@ package com.core.data.post
 import androidx.paging.PagingData
 import com.core.model.data.ImageSource
 import com.core.model.data.PostSource
+import com.core.model.data.PostSources
 import com.core.model.data.TagSource
 import kotlinx.coroutines.flow.Flow
 
@@ -24,5 +25,5 @@ interface PostRepository {
     suspend fun getPosts(year: Int, month: Int): List<PostSource>
 
     // 특정 년도/월 post paging 요청
-    fun getPostPaging(year: Int, month: Int): Flow<PagingData<PostSource>>
+    fun getPostPaging(year: Int, month: Int): Flow<PagingData<PostSources>>
 }

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalPagingSource.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalPagingSource.kt
@@ -70,6 +70,6 @@ class PostLocalPagingSource(
     }
 
     companion object {
-        const val PAGING_SIZE = 3
+        const val PAGING_SIZE = 1
     }
 }

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalPagingSource.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalPagingSource.kt
@@ -17,9 +17,14 @@ import java.time.YearMonth
 class PostLocalPagingSource(
     private val postDao: PostDao
 ) : PagingSource<YearMonth, PostSources>() {
+
     override fun getRefreshKey(state: PagingState<YearMonth, PostSources>): YearMonth? {
-        return state.anchorPosition?.let { position ->
-            state.closestPageToPosition(position)?.prevKey?.plusMonths(1)
+        return state.anchorPosition?.let { page ->
+            val closedPage = state.closestPageToPosition(page)
+            return closedPage?.let {
+                // 최근에 로드한 정보가 현재 정보인 경우
+                YearMonth.of(it.data[1].year, it.data[1].month)
+            }
         }
     }
 
@@ -65,6 +70,6 @@ class PostLocalPagingSource(
     }
 
     companion object {
-        const val PAGING_SIZE = 1
+        const val PAGING_SIZE = 3
     }
 }

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
@@ -109,4 +109,8 @@ class PostLocalRepositoryImpl @Inject constructor(
             }
         ).flow
     }
+
+    override suspend fun removePost(postId: Long) = coroutineScope {
+        postDao.deletePost(postId)
+    }
 }

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
@@ -98,12 +98,11 @@ class PostLocalRepositoryImpl @Inject constructor(
     override fun getPostPaging(
         year: Int,
         month: Int
-    ): Flow<PagingData<PostSource>> {
+    ): Flow<PagingData<PostSources>> {
         return Pager(
             config = PagingConfig(
                 pageSize = PostLocalPagingSource.PAGING_SIZE,
-                enablePlaceholders = true,
-                maxSize = PostLocalPagingSource.PAGING_SIZE * 5
+                enablePlaceholders = true
             ),
             pagingSourceFactory = {
                 PostLocalPagingSource(postDao)

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
@@ -102,7 +102,7 @@ class PostLocalRepositoryImpl @Inject constructor(
         return Pager(
             config = PagingConfig(
                 pageSize = PostLocalPagingSource.PAGING_SIZE,
-                enablePlaceholders = true
+                maxSize = PostLocalPagingSource.PAGING_SIZE * 3
             ),
             pagingSourceFactory = {
                 PostLocalPagingSource(postDao)

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
@@ -101,8 +101,7 @@ class PostLocalRepositoryImpl @Inject constructor(
     ): Flow<PagingData<PostSources>> {
         return Pager(
             config = PagingConfig(
-                pageSize = PostLocalPagingSource.PAGING_SIZE,
-                maxSize = PostLocalPagingSource.PAGING_SIZE * 3
+                pageSize = PostLocalPagingSource.PAGING_SIZE
             ),
             pagingSourceFactory = {
                 PostLocalPagingSource(postDao)

--- a/core/database/src/main/java/com/core/database/dao/PostDao.kt
+++ b/core/database/src/main/java/com/core/database/dao/PostDao.kt
@@ -43,4 +43,7 @@ interface PostDao {
 
     @Delete
     suspend fun deleteTags(tags: List<TagEntity>)
+
+    @Query("DELETE FROM post WHERE id = :postId")
+    suspend fun deletePost(postId: Long)
 }

--- a/core/designsystem/src/main/java/com/core/designsystem/modifiers/Pager.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/modifiers/Pager.kt
@@ -12,7 +12,7 @@ fun Modifier.pagerHingeTransition(page: Int, pagerState: PagerState) = graphicsL
     val pageOffset = pagerState.calculateCurrentOffsetForPage(page)
 
     translationX = pageOffset * size.width
-    translationY = pageOffset * size.height
+    translationY = 1 - pageOffset * size.height
     transformOrigin = TransformOrigin(0f, 0f)
 
     when {

--- a/core/designsystem/src/main/java/com/core/designsystem/util/Resources.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/util/Resources.kt
@@ -1,10 +1,11 @@
 package com.core.designsystem.util
 
-import androidx.annotation.DimenRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 
 @Composable
 fun getString(@StringRes id: Int) = stringResource(id = id)
+
+@Composable
+fun getString(@StringRes id: Int, vararg values: Any) = stringResource(id = id, formatArgs = values)

--- a/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonth.kt
+++ b/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonth.kt
@@ -1,10 +1,21 @@
 package com.core.domain.post
 
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.core.data.post.PostRepository
+import com.core.model.domain.Post
+import com.core.model.domain.toPost
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
 /**
  * 월별 기록 paging 요청 use case
  */
-class GetPostPageByMonth {
-    suspend operator fun invoke(year: Int, month: Int) {
-
+class GetPostPageByMonth @Inject constructor(
+    private val postRepository: PostRepository
+) {
+    operator fun invoke(year: Int, month: Int): Flow<PagingData<Post>> {
+        return postRepository.getPostPaging(year, month).map { it.map { post -> post.toPost() } }
     }
 }

--- a/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonthUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonthUseCase.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 /**
  * 월별 기록 paging 요청 use case
  */
-class GetPostPageByMonth @Inject constructor(
+class GetPostPageByMonthUseCase @Inject constructor(
     private val postRepository: PostRepository
 ) {
     operator fun invoke(year: Int, month: Int): Flow<PagingData<Post>> {

--- a/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonthUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonthUseCase.kt
@@ -3,8 +3,8 @@ package com.core.domain.post
 import androidx.paging.PagingData
 import androidx.paging.map
 import com.core.data.post.PostRepository
-import com.core.model.domain.Post
-import com.core.model.domain.toPost
+import com.core.model.domain.Posts
+import com.core.model.domain.toPosts
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class GetPostPageByMonthUseCase @Inject constructor(
     private val postRepository: PostRepository
 ) {
-    operator fun invoke(year: Int, month: Int): Flow<PagingData<Post>> {
-        return postRepository.getPostPaging(year, month).map { it.map { post -> post.toPost() } }
+    operator fun invoke(year: Int, month: Int): Flow<PagingData<Posts>> {
+        return postRepository.getPostPaging(year, month).map { it.map { post -> post.toPosts() } }
     }
 }

--- a/core/domain/src/main/java/com/core/domain/post/RemovePostUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/RemovePostUseCase.kt
@@ -1,0 +1,12 @@
+package com.core.domain.post
+
+import com.core.data.post.PostRepository
+import javax.inject.Inject
+
+class RemovePostUseCase @Inject constructor(
+    private val postRepository: PostRepository
+) {
+    suspend operator fun invoke(postId: Long) {
+        postRepository.removePost(postId)
+    }
+}

--- a/core/model/src/main/java/com/core/model/data/PostSource.kt
+++ b/core/model/src/main/java/com/core/model/data/PostSource.kt
@@ -15,6 +15,14 @@ data class PostSource(
     val tags: List<TagSource> // 태그
 )
 
+/**
+ * 하나의 PostSource page
+ */
+data class PostSources(
+    val year: Int, val month: Int,
+    val posts: List<PostSource>
+)
+
 fun PostSource.toPostEntity() = PostEntity(
     id = id,
     year = year,

--- a/core/model/src/main/java/com/core/model/domain/Post.kt
+++ b/core/model/src/main/java/com/core/model/domain/Post.kt
@@ -1,6 +1,7 @@
 package com.core.model.domain
 
 import com.core.model.data.PostSource
+import com.core.model.data.PostSources
 
 /**
  * domain Layer: Post 정보
@@ -13,6 +14,14 @@ data class Post(
     val content: String?,
     val images: List<Image>,
     val tags: List<Tag>
+)
+
+/**
+ * Post 한 page 단위
+ */
+data class Posts(
+    val year: Int, val month: Int,
+    val posts: List<Post>
 )
 
 fun Post.toSource() = PostSource(
@@ -33,4 +42,9 @@ fun PostSource.toPost() = Post(
     content = content,
     images = images.map { it.toImage() },
     tags = tags.map { it.toTag() }
+)
+
+fun PostSources.toPosts() = Posts(
+    year = year, month = month,
+    posts = posts.map { it.toPost() }
 )

--- a/core/model/src/main/java/com/core/model/feature/CellType.kt
+++ b/core/model/src/main/java/com/core/model/feature/CellType.kt
@@ -5,6 +5,7 @@ package com.core.model.feature
  */
 enum class CellType {
     POST,
+    POSTS,
     IMAGE,
     TAG
 }

--- a/core/model/src/main/java/com/core/model/feature/PostUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/PostUiModel.kt
@@ -1,5 +1,7 @@
 package com.core.model.feature
 
+import com.core.model.domain.Post
+
 /**
  * Post Ui 정보
  */
@@ -11,3 +13,12 @@ data class PostUiModel(
     val content: String,
     val images: List<ImageUiModel>
 ) : Model(id, CellType.POST)
+
+fun Post.toPostUiModel() = PostUiModel(
+    id = id,
+    year = year,
+    month = month,
+    day = day,
+    content = content ?: "",
+    images = images.map { image -> image.toImageUiModel() }
+)

--- a/core/model/src/main/java/com/core/model/feature/PostUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/PostUiModel.kt
@@ -1,24 +1,33 @@
 package com.core.model.feature
 
 import com.core.model.domain.Post
+import com.core.model.domain.Posts
+import java.time.LocalDate
+import java.time.YearMonth
 
 /**
  * Post Ui 정보
  */
 data class PostUiModel(
     override val id: Long?,
-    val year: Int,
-    val month: Int,
-    val day: Int,
+    val date: LocalDate,
     val content: String,
     val images: List<ImageUiModel>
 ) : Model(id, CellType.POST)
 
+data class PostsUiModel(
+    val date: YearMonth,
+    val posts: List<PostUiModel>
+) : Model(null, CellType.POSTS)
+
 fun Post.toPostUiModel() = PostUiModel(
     id = id,
-    year = year,
-    month = month,
-    day = day,
+    date = LocalDate.of(year, month, day),
     content = content ?: "",
     images = images.map { image -> image.toImageUiModel() }
+)
+
+fun Posts.toPostsUiModel() = PostsUiModel(
+    date = YearMonth.of(year, month),
+    posts = posts.map { it.toPostUiModel() }
 )

--- a/core/ui/src/main/java/com/core/ui/date/YearMonthDayText.kt
+++ b/core/ui/src/main/java/com/core/ui/date/YearMonthDayText.kt
@@ -74,6 +74,7 @@ fun ColumnDayAndDate(
 fun RowMonthAndName(
     modifier: Modifier = Modifier,
     date: YearMonth,
+    yearTextStyle: TextStyle = MaterialTheme.typography.h6,
     monthTextStyle: TextStyle = MaterialTheme.typography.h2,
     nameTextStyle: TextStyle = MaterialTheme.typography.h5,
     contentColor: Color = HarooTheme.colors.text
@@ -84,6 +85,12 @@ fun RowMonthAndName(
             CompositionLocalProvider(
                 LocalContentColor provides contentColor
             ) {
+                Text(
+                    modifier = Modifier
+                        .layoutId("Year"),
+                    text = date.year.toString(),
+                    style = yearTextStyle
+                )
                 Text(
                     modifier = Modifier
                         .layoutId("Month"),
@@ -99,18 +106,21 @@ fun RowMonthAndName(
             }
         }
     ) { measureables, constraints ->
+        val year = measureables.find { it.layoutId == "Year" }!!.measure(constraints)
         val month = measureables.find { it.layoutId == "Month" }!!.measure(constraints)
         val displayName = measureables.find { it.layoutId == "DisplayName" }!!.measure(constraints)
 
-        val displayNameY = month[LastBaseline] - displayName[FirstBaseline]
+        val monthY = year[LastBaseline] + 5
+        val displayNameY = monthY + month[LastBaseline] - displayName[FirstBaseline]
         layout(
             width = month.width + displayName.width,
             height = displayNameY + displayName.measuredHeight
         ) {
-            month.placeRelative(x = 0, y = 0)
+            year.placeRelative(x = 0, y = 0)
+            month.placeRelative(x = 0, y = monthY)
             displayName.placeRelative(
                 x = month.measuredWidth,
-                y = month[LastBaseline] - displayName[FirstBaseline]
+                y = displayNameY
             )
         }
     }

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -40,9 +40,8 @@ fun SimplePostItem(
                 modifier = Modifier
                     .padding(10.dp)
                     .size(20.dp)
-                    .align(Alignment.TopEnd)
-                    .noRippleClickable { onRemovePost(post) },
-                onClick = { }
+                    .align(Alignment.TopEnd),
+                onClick = { onRemovePost(post) }
             ) {
                 Icon(
                     imageVector = Icons.Outlined.Close,

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("haroo.android.library")
     id("haroo.android.library.compose")
+    id("haroo.android.hilt")
 }
 
 android {
@@ -11,6 +12,7 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:model"))
     implementation(project(":core:designsystem"))
+    implementation(project(":core:domain"))
 
     implementation(libs.paging.compose)
 }

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -19,6 +20,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemsIndexed
 import com.core.designsystem.components.HarooButton
@@ -28,6 +30,7 @@ import com.core.designsystem.components.calendar.Calendar
 import com.core.designsystem.modifiers.pagerHingeTransition
 import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.PostUiModel
+import com.core.model.feature.PostsUiModel
 import com.core.ui.date.DateWithImage
 import com.core.ui.date.RowMonthAndName
 import com.core.ui.post.SimplePostItem
@@ -49,13 +52,26 @@ fun HomeScreen(
         homeViewModel.homeUiEvent.collect {
             when (it) {
                 HomeUiEvent.Initialized -> {}
-                is HomeUiEvent.Success.RemovePost -> {
-                    postPagingItems.refresh()
-                }
+                is HomeUiEvent.Success.RemovePost -> postPagingItems.refresh()
             }
         }
     }
 
+    HomeScreen(
+        postPagingItems = postPagingItems,
+        scrollState = scrollState,
+        toPostScreen = {},
+        onRemovePost = homeViewModel::removePost
+    )
+}
+
+@Composable
+fun HomeScreen(
+    postPagingItems: LazyPagingItems<PostsUiModel>,
+    scrollState: LazyListState,
+    toPostScreen: (LocalDate)->Unit,
+    onRemovePost: (PostUiModel) -> Unit
+) {
     LazyColumn(
         modifier = Modifier
             .statusBarsPadding()
@@ -71,9 +87,7 @@ fun HomeScreen(
                     date = postsUiModel.date,
                     posts = postsUiModel.posts,
                     onClickPost = {},
-                    onRemovePost = {
-                        homeViewModel.removePost(index, it)
-                    }
+                    onRemovePost = onRemovePost
                 )
             }
         }

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -18,11 +18,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.itemsIndexed
+import androidx.paging.compose.items
 import com.core.designsystem.components.HarooButton
 import com.core.designsystem.components.HarooDashLine
 import com.core.designsystem.components.HarooDivider
@@ -37,6 +38,8 @@ import com.core.ui.date.RowMonthAndName
 import com.core.ui.post.SimplePostItem
 import java.time.LocalDate
 import java.time.YearMonth
+
+private val componentVerticalSpacer = 16.dp
 
 @Composable
 fun HomeScreen(
@@ -82,7 +85,10 @@ fun HomeScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         state = scrollState
     ) {
-        itemsIndexed(items = postPagingItems, key = { index, posts -> posts.date }) { index, posts ->
+        items(
+            items = postPagingItems,
+            key = { posts -> posts.date }
+        ) { posts ->
             posts?.let { postsUiModel ->
                 MonthlyContainer(
                     date = postsUiModel.date,
@@ -109,11 +115,11 @@ fun MonthlyContainer(
     val groupedPosts = remember(posts) { posts.associateBy { it.date } }
     Column(modifier = modifier.fillMaxWidth()) {
         Column(
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = componentVerticalSpacer),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             RowMonthAndName(
-                modifier = Modifier.padding(vertical = 24.dp),
+                modifier = Modifier.padding(vertical = componentVerticalSpacer),
                 date = date
             )
             MonthlyCalendar(date = date, posts = groupedPosts)
@@ -135,15 +141,17 @@ fun MonthlyContainer(
 fun MonthlyCalendar(
     date: YearMonth,
     modifier: Modifier = Modifier,
+    verticalSpace: Dp = 10.dp,
+    horizontalSpace: Dp = 4.dp,
     posts: Map<LocalDate, PostUiModel>
 ) {
     Calendar(
-        modifier = modifier.padding(vertical = 16.dp),
-        space = 10.dp,
+        modifier = modifier.padding(vertical = componentVerticalSpacer),
+        space = verticalSpace,
         currentMonth = date,
         dayContent = {
             DateWithImage(
-                modifier = Modifier.padding(horizontal = 4.dp),
+                modifier = Modifier.padding(horizontal = horizontalSpace),
                 state = it,
                 image = posts[it.date]?.images?.firstOrNull()
             )
@@ -166,8 +174,9 @@ fun DailyContainer(
     val pagerState = rememberPagerState()
     val dateCount = remember(date) { date.lengthOfMonth() }
     HorizontalPager(
-        modifier = modifier.padding(vertical = 16.dp),
-        pageCount = dateCount, key = { it },
+        modifier = modifier.padding(vertical = componentVerticalSpacer),
+        pageCount = dateCount,
+        key = { it },
         beyondBoundsPageCount = 3,
         state = pagerState
     ) {

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -29,6 +29,7 @@ import com.core.designsystem.components.HarooDivider
 import com.core.designsystem.components.calendar.Calendar
 import com.core.designsystem.modifiers.pagerHingeTransition
 import com.core.designsystem.theme.HarooTheme
+import com.core.designsystem.util.getString
 import com.core.model.feature.PostUiModel
 import com.core.model.feature.PostsUiModel
 import com.core.ui.date.DateWithImage
@@ -69,7 +70,7 @@ fun HomeScreen(
 fun HomeScreen(
     postPagingItems: LazyPagingItems<PostsUiModel>,
     scrollState: LazyListState,
-    toPostScreen: (LocalDate)->Unit,
+    toPostScreen: (LocalDate) -> Unit,
     onRemovePost: (PostUiModel) -> Unit
 ) {
     LazyColumn(
@@ -123,7 +124,7 @@ fun MonthlyContainer(
                 onRemovePost = onRemovePost
             )
         }
-        MonthlyDivider(date = date)
+        MonthlyDivider(date = date, onClickMonthBtn = {})
     }
 }
 
@@ -184,20 +185,21 @@ fun DailyContainer(
 @Composable
 fun MonthlyDivider(
     date: YearMonth,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClickMonthBtn: (YearMonth) -> Unit
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        HarooDivider(
-            modifier = Modifier.weight(1f)
-        )
+        HarooDivider(modifier = Modifier.weight(1f))
         HarooButton(
-            shape = RoundedCornerShape(topStart = 100f, bottomStart = 100f),
-            onClick = { }
+            shape = RoundedCornerShape(
+                topStart = 100f, bottomStart = 100f
+            ),
+            onClick = { onClickMonthBtn(date) }
         ) {
-            Text(text = "${date.monthValue}월 보기")
+            Text(text = getString(id = R.string.btn_view_month, date.monthValue))
         }
     }
 }

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -51,7 +51,7 @@ fun HomeScreen(
             it?.let { postsUiModel ->
                 MonthlyContainer(
                     date = postsUiModel.date,
-                    posts = emptyList()
+                    posts = postsUiModel.posts
                 )
             }
         }
@@ -67,7 +67,7 @@ fun MonthlyContainer(
     modifier: Modifier = Modifier,
     posts: List<PostUiModel>
 ) {
-    val groupedPosts = remember(posts.size) { posts.associateBy { it.date } }
+    val groupedPosts = remember(posts) {posts.associateBy { it.date }}
     Column(modifier = modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.padding(horizontal = 16.dp),

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,6 +15,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.items
 import com.core.designsystem.components.HarooButton
 import com.core.designsystem.components.HarooDashLine
 import com.core.designsystem.components.HarooDivider
@@ -28,16 +32,29 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 @Composable
-fun HomeScreen() {
+fun HomeScreen(
+    homeViewModel: HomeViewModel = hiltViewModel()
+) {
+    val posts = homeViewModel.posts.collectAsLazyPagingItems()
+    val scrollState = rememberLazyListState(1)
+
     LazyColumn(
         modifier = Modifier
             .statusBarsPadding()
             .navigationBarsPadding()
             .imePadding()
             .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground)),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+        state = scrollState
     ) {
-        item { MonthlyContainer(date = YearMonth.now(), posts = emptyList()) }
+        items(items = posts, key = { it.date }) {
+            it?.let { postsUiModel ->
+                MonthlyContainer(
+                    date = postsUiModel.date,
+                    posts = emptyList()
+                )
+            }
+        }
     }
 }
 
@@ -50,9 +67,7 @@ fun MonthlyContainer(
     modifier: Modifier = Modifier,
     posts: List<PostUiModel>
 ) {
-    val groupedPosts = remember(posts.size) {
-        posts.associateBy { LocalDate.of(it.year, it.month, it.day) }
-    }
+    val groupedPosts = remember(posts.size) { posts.associateBy { it.date } }
     Column(modifier = modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.padding(horizontal = 16.dp),

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.feature.home
 
+import android.content.res.Configuration
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -15,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -34,10 +36,14 @@ import java.time.YearMonth
 
 @Composable
 fun HomeScreen(
-    homeViewModel: HomeViewModel = hiltViewModel()
+    homeViewModel: HomeViewModel = hiltViewModel(),
+    configuration: Configuration = LocalConfiguration.current
 ) {
     val postPagingItems = homeViewModel.posts.collectAsLazyPagingItems()
-    val scrollState = rememberLazyListState(1)
+    val scrollState = rememberLazyListState(
+        initialFirstVisibleItemIndex = 1,
+        initialFirstVisibleItemScrollOffset = -configuration.screenHeightDp / 3
+    )
 
     LaunchedEffect(key1 = Unit) {
         homeViewModel.homeUiEvent.collect {

--- a/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
@@ -32,11 +32,11 @@ class HomeViewModel @Inject constructor(
     ).map { it.map { post -> post.toPostsUiModel() } }
         .cachedIn(viewModelScope)
 
-    fun removePost(postId: Int, postUiModel: PostUiModel) {
+    fun removePost(postUiModel: PostUiModel) {
         viewModelScope.launch {
             postUiModel.id?.let {
                 removePostUseCase(it)
-                _homeUiEvent.value = HomeUiEvent.Success.RemovePost(postId, postUiModel)
+                _homeUiEvent.value = HomeUiEvent.Success.RemovePost
             }
         }
     }
@@ -45,9 +45,7 @@ class HomeViewModel @Inject constructor(
 sealed interface HomeUiEvent {
     object Initialized : HomeUiEvent
     sealed interface Success : HomeUiEvent {
-        data class RemovePost(
-            val postsId: Int,
-            val post: PostUiModel
-        ) : Success
+        // Post 제거 성공 event
+        object RemovePost: Success
     }
 }

--- a/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
@@ -6,8 +6,12 @@ import androidx.paging.cachedIn
 import androidx.paging.map
 import com.core.domain.post.GetPostPageByMonthUseCase
 import com.core.domain.post.RemovePostUseCase
+import com.core.model.feature.PostUiModel
 import com.core.model.feature.toPostsUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.time.YearMonth
@@ -18,15 +22,32 @@ class HomeViewModel @Inject constructor(
     getPostPageByMonthUseCase: GetPostPageByMonthUseCase,
     private val removePostUseCase: RemovePostUseCase
 ) : ViewModel() {
+
+    private val _homeUiEvent = MutableStateFlow<HomeUiEvent>(HomeUiEvent.Initialized)
+    val homeUiEvent: StateFlow<HomeUiEvent> = _homeUiEvent.asStateFlow()
+
     private val initDay = YearMonth.now()
     val posts = getPostPageByMonthUseCase(
         initDay.year, initDay.monthValue
     ).map { it.map { post -> post.toPostsUiModel() } }
         .cachedIn(viewModelScope)
 
-    fun removePost(postId: Long) {
+    fun removePost(postId: Int, postUiModel: PostUiModel) {
         viewModelScope.launch {
-            removePostUseCase(postId)
+            postUiModel.id?.let {
+                removePostUseCase(it)
+                _homeUiEvent.value = HomeUiEvent.Success.RemovePost(postId, postUiModel)
+            }
         }
+    }
+}
+
+sealed interface HomeUiEvent {
+    object Initialized : HomeUiEvent
+    sealed interface Success : HomeUiEvent {
+        data class RemovePost(
+            val postsId: Int,
+            val post: PostUiModel
+        ) : Success
     }
 }

--- a/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import androidx.paging.map
 import com.core.domain.post.GetPostPageByMonthUseCase
-import com.core.model.feature.toPostUiModel
+import com.core.model.feature.toPostsUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
 import java.time.YearMonth
@@ -18,6 +18,6 @@ class HomeViewModel @Inject constructor(
     private val initDay = YearMonth.now()
     val posts = getPostPageByMonthUseCase(
         initDay.year, initDay.monthValue
-    ).map { it.map { post -> post.toPostUiModel() } }
+    ).map { it.map { post -> post.toPostsUiModel() } }
         .cachedIn(viewModelScope)
 }

--- a/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
@@ -1,0 +1,23 @@
+package com.feature.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
+import androidx.paging.map
+import com.core.domain.post.GetPostPageByMonthUseCase
+import com.core.model.feature.toPostUiModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.map
+import java.time.YearMonth
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    getPostPageByMonthUseCase: GetPostPageByMonthUseCase
+) : ViewModel() {
+    private val initDay = YearMonth.now()
+    val posts = getPostPageByMonthUseCase(
+        initDay.year, initDay.monthValue
+    ).map { it.map { post -> post.toPostUiModel() } }
+        .cachedIn(viewModelScope)
+}

--- a/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
@@ -5,19 +5,28 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import androidx.paging.map
 import com.core.domain.post.GetPostPageByMonthUseCase
+import com.core.domain.post.RemovePostUseCase
 import com.core.model.feature.toPostsUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import java.time.YearMonth
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    getPostPageByMonthUseCase: GetPostPageByMonthUseCase
+    getPostPageByMonthUseCase: GetPostPageByMonthUseCase,
+    private val removePostUseCase: RemovePostUseCase
 ) : ViewModel() {
     private val initDay = YearMonth.now()
     val posts = getPostPageByMonthUseCase(
         initDay.year, initDay.monthValue
     ).map { it.map { post -> post.toPostsUiModel() } }
         .cachedIn(viewModelScope)
+
+    fun removePost(postId: Long) {
+        viewModelScope.launch {
+            removePostUseCase(postId)
+        }
+    }
 }

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="btn_view_month">%2d월 보기</string>
+</resources>


### PR DESCRIPTION
#### 📌 내용
HomeScreen에서 월별 Post 정보를 Paging으로 받아와 화면에 보여주기
( + 세부 수정 사항 변경 )

#### 🛠 Done
- [x] 월별 Post 정보를 Paging으로 불러오기
- [x] 해당 내용을 List로 보여주기
- [x] Calendar에 Post 정보 보여주기
- [x] Daily에 Post 정보 보여주기
- [x] Daily Post 제거 로직 구현하기
- [x] Daily Post 제거 및 UI 반영
- [x] UiState로 전체 State 관리하기

#### 🪴 UI

https://user-images.githubusercontent.com/22411296/232202867-35baff32-69cd-497e-b6e5-9dc94a70aaa9.mp4

#### 🌹 어려웠던 부분
1. Paging 단위 조절
```
PagingSources는 PostEntity를 배열을 하나의 Page로 받기를 원했으나, Paging3 특성 상 반환 값이 List이어야 하기 때문에 PostEntity 배열을 프로퍼티로 갖는 별도의 data class PostsSource를 만들고, PostSource를 PagingSource의 반환값으로 지정
```
이에 더해, 한 Page 당 하나의 Month가 아닌, 3개의 Month를 포함하도록 수정하였습니다. 🤗


2. Paging refresh 시, load할 key 지정
특정 Post 제거 시, Paging을 refresh 해줄 필요가 있었으나, Scroll의 위치가 보존되지 않는 이슈가 있었습니다.

원인을 파악해보니, Refresh 시에 적용되는 key 값이 기존 화면에 보여지고 있던 값을 유지하지 못하는 것을 파악하고 이를 상황에 맞게 수정하였습니다.
```
override fun getRefreshKey(state: PagingState<YearMonth, PostSources>): YearMonth? {
    return state.anchorPosition?.let { page ->
        val closedPage = state.closestPageToPosition(page)
        return closedPage?.let {
            // 최근에 로드한 정보가 현재 정보인 경우
            YearMonth.of(it.data[1].year, it.data[1].month)
        }
    }
}
```

#### 🏠 관련 Issue
Closed #32 