### PR TITLE
[UI] #34 Monthly Screen

### DIFF
--- a/core/common/src/main/java/com/core/common/ext/LocalDateExtension.kt
+++ b/core/common/src/main/java/com/core/common/ext/LocalDateExtension.kt
@@ -24,4 +24,5 @@ fun LocalDate.getDate(): String = dayOfMonth.padStart(2)
 /**
  * 요일 출력(영어로)
  */
-fun LocalDate.dayOfWeek(textStyle: TextStyle = TextStyle.FULL): String = dayOfWeek.getDisplayName(textStyle, Locale.US)
+fun LocalDate.dayOfWeek(textStyle: TextStyle = TextStyle.FULL): String =
+    dayOfWeek.getDisplayName(textStyle, Locale.US).uppercase()

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Button.kt
@@ -1,5 +1,6 @@
 package com.core.designsystem.components
 
+import androidx.compose.animation.core.*
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -8,17 +9,21 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.core.designsystem.modifiers.noRippleClickable
 import com.core.designsystem.theme.AllForMemoryTheme
 import com.core.designsystem.theme.HarooTheme
+import kotlin.math.abs
 
 @Composable
 fun HarooButton(
@@ -85,6 +90,50 @@ fun ButtonPreview() {
             ) {
                 Text(text = "추가")
             }
+        }
+    }
+}
+
+@Composable
+fun HarooRadioButton(
+    modifier: Modifier = Modifier,
+    contentColor: Color = HarooTheme.colors.text,
+    radioSize: Dp = 32.dp,
+    selected: Boolean = false,
+    onSelected: () -> Unit
+) {
+    val currentState = remember(selected) {
+        MutableTransitionState(selected).apply { targetState = selected.not() }
+    }
+    val transition = updateTransition(targetState = currentState, label = null)
+    val radioOffset = transition.animateFloat(
+        transitionSpec = {
+            tween(delayMillis = 0, durationMillis = 300, easing = LinearEasing)
+        }, label = ""
+    ) {
+        if (it.currentState) 1f else 0f
+    }
+
+    HarooButton(
+        modifier = modifier
+            .height(radioSize)
+            .width(radioSize * 2),
+        onClick = onSelected,
+        contentPadding = PaddingValues()
+    ) {
+        HarooSurface(
+            modifier = Modifier
+                .fillMaxHeight()
+                .aspectRatio(1f)
+                .graphicsLayer {
+                    translationX = radioOffset.value * radioSize.value * 2 - radioSize.value
+                    scaleX = 1 - abs(0.5 - radioOffset.value).toFloat()
+                    scaleY = 1 - abs(0.5 - radioOffset.value).toFloat()
+                },
+            shape = MaterialTheme.shapes.small,
+            alpha = 1f
+        ) {
+
         }
     }
 }

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Divider.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Divider.kt
@@ -2,12 +2,10 @@ package com.core.designsystem.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -61,6 +59,26 @@ fun HarooDashLine(
 }
 
 @Composable
+fun HarooVerticalDivider(
+    modifier: Modifier = Modifier,
+    color: Color = HarooTheme.colors.uiBorder,
+    alpha: Float = 1f,
+    thickness: Float = 3f
+) {
+    Canvas(
+        modifier = modifier.fillMaxHeight()
+    ) {
+        drawLine(
+            color = color,
+            start = Offset(0f, 0f),
+            end = Offset(0f, size.height),
+            strokeWidth = thickness,
+            alpha = alpha
+        )
+    }
+}
+
+@Composable
 @Preview(name = "basic divider")
 fun HarooDividerPreview() {
     AllForMemoryTheme {
@@ -71,10 +89,12 @@ fun HarooDividerPreview() {
                 .background(
                     Brush.linearGradient(HarooTheme.colors.gradient4_1)
                 ),
-            verticalArrangement = Arrangement.SpaceEvenly
+            verticalArrangement = Arrangement.SpaceEvenly,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             HarooDivider()
             HarooDashLine()
+            HarooVerticalDivider()
         }
     }
 }

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Divider.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Divider.kt
@@ -63,8 +63,12 @@ fun HarooVerticalDivider(
     modifier: Modifier = Modifier,
     color: Color = HarooTheme.colors.uiBorder,
     alpha: Float = 1f,
-    thickness: Float = 3f
+    thickness: Float = 3f,
+    dash: Float = 10f
 ) {
+    val pathEffect = PathEffect.dashPathEffect(
+        floatArrayOf(dash, dash), 0f
+    )
     Canvas(
         modifier = modifier.fillMaxHeight()
     ) {
@@ -73,7 +77,8 @@ fun HarooVerticalDivider(
             start = Offset(0f, 0f),
             end = Offset(0f, size.height),
             strokeWidth = thickness,
-            alpha = alpha
+            alpha = alpha,
+            pathEffect = pathEffect
         )
     }
 }

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Header.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Header.kt
@@ -1,5 +1,6 @@
 package com.core.designsystem.components
 
+import android.app.ActionBar
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
@@ -11,6 +12,36 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.core.designsystem.theme.HarooTheme
+
+@Composable
+fun HarooHeader(
+    modifier: Modifier = Modifier,
+    title: String,
+    onBackPressed: () -> Unit
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(AppBarDefaults.ContentPadding),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CompositionLocalProvider(
+            LocalContentColor provides HarooTheme.colors.text
+        ) {
+            IconButton(onClick = onBackPressed) {
+                Icon(
+                    imageVector = Icons.Outlined.Close,
+                    contentDescription = "back"
+                )
+            }
+            Text(
+                modifier = Modifier.weight(1f),
+                text = title,
+                style = MaterialTheme.typography.subtitle1
+            )
+        }
+    }
+}
 
 @Composable
 fun BackAndRightButtonHeader(

--- a/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/components/Image.kt
@@ -180,6 +180,7 @@ fun HarooImage(
                 contentScale = contentScale
             )
             is ImageType.AsyncImage -> AsyncImage(
+                modifier = Modifier.fillMaxSize(),
                 model = imageType.image.imageUrl,
                 contentDescription = imageType.contentDescription,
                 contentScale = contentScale

--- a/core/designsystem/src/main/java/com/core/designsystem/theme/Shape.kt
+++ b/core/designsystem/src/main/java/com/core/designsystem/theme/Shape.kt
@@ -5,7 +5,7 @@ import androidx.compose.material.Shapes
 import androidx.compose.ui.unit.dp
 
 val Shapes = Shapes(
-    small = RoundedCornerShape(percent = 50),
+    small = RoundedCornerShape(percent = 100),
     medium = RoundedCornerShape(size = 4.dp),
     large = RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp)
 )

--- a/core/domain/src/main/java/com/core/domain/post/GetPostByMonthUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/GetPostByMonthUseCase.kt
@@ -1,10 +1,18 @@
 package com.core.domain.post
 
+import com.core.data.post.PostRepository
+import com.core.model.domain.Post
+import com.core.model.domain.toPost
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
 /**
  * 월별 기록 요청 use case
  */
-class GetPostByMonthUseCase {
-    suspend operator fun invoke(year: Int, month: Int) {
-
+class GetPostByMonthUseCase @Inject constructor(
+    private val postRepository: PostRepository
+) {
+    suspend operator fun invoke(year: Int, month: Int): List<Post> {
+        return postRepository.getPosts(year, month).map { posts -> posts.toPost() }
     }
 }

--- a/core/model/src/main/java/com/core/model/feature/PostUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/PostUiModel.kt
@@ -12,7 +12,8 @@ data class PostUiModel(
     override val id: Long?,
     val date: LocalDate,
     val content: String,
-    val images: List<ImageUiModel>
+    val images: List<ImageUiModel>,
+    val tags: List<TagUiModel>
 ) : Model(id, CellType.POST)
 
 data class PostsUiModel(
@@ -24,7 +25,8 @@ fun Post.toPostUiModel() = PostUiModel(
     id = id,
     date = LocalDate.of(year, month, day),
     content = content ?: "",
-    images = images.map { image -> image.toImageUiModel() }
+    images = images.map { image -> image.toImageUiModel() },
+    tags = tags.map { tag -> tag.toTagUiModel() }
 )
 
 fun Posts.toPostsUiModel() = PostsUiModel(

--- a/core/ui/src/main/java/com/core/ui/date/YearMonthDayText.kt
+++ b/core/ui/src/main/java/com/core/ui/date/YearMonthDayText.kt
@@ -53,7 +53,7 @@ fun ColumnDayAndDate(
 
         val dayX = if (day.width <= dayOfWeek.width) (dayOfWeek.width - day.width) / 2 else 0
         val dayOfWeekX = if (day.width < dayOfWeek.width) 0 else (day.width - dayOfWeek.width) / 2
-        val dayOfWeekY = day[LastBaseline] + 30
+        val dayOfWeekY = day[LastBaseline] + 10
         layout(
             width = max(day.width, dayOfWeek.width),
             height = dayOfWeekY + dayOfWeek.measuredHeight

--- a/core/ui/src/main/java/com/core/ui/image/ImageList.kt
+++ b/core/ui/src/main/java/com/core/ui/image/ImageList.kt
@@ -4,8 +4,12 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
@@ -101,6 +105,72 @@ fun HarooImageList(
                 )
                 x += it.width + spaceBy
             }
+        }
+    }
+}
+
+@Composable
+fun HarooGridImages(
+    modifier: Modifier = Modifier,
+    shape: Shape = MaterialTheme.shapes.medium,
+    images: List<ImageUiModel>, // 이미지 정보 리스트
+    content: @Composable (ImageUiModel) -> Unit
+) {
+    val imageCount = remember(images.size) { images.size }
+
+    Layout(
+        modifier = modifier.clip(shape),
+        content = { images.forEach { content(it) } }
+    ) { measureables, constraints ->
+        val imagesWidth = constraints.maxWidth / (if (imageCount >= 2) 2 else 1)
+        val firstImage = measureables.getOrNull(0)?.measure(
+            constraints.copy(
+                maxWidth = imagesWidth,
+                maxHeight = when (imageCount) {
+                    1, 3, 4 -> imagesWidth / 2
+                    else -> imagesWidth
+                }
+            )
+        )
+        val secondImage = measureables.getOrNull(1)?.measure(
+            constraints.copy(
+                maxWidth = imagesWidth,
+                maxHeight = when (imageCount) {
+                    3, 4 -> imagesWidth / 2
+                    else -> imagesWidth
+                }
+            )
+        )
+        val thirdImage = measureables.getOrNull(2)?.measure(
+            constraints.copy(
+                maxWidth = imagesWidth,
+                maxHeight = when (imageCount) {
+                    3 -> imagesWidth
+                    else -> imagesWidth / 2
+                }
+            )
+        )
+        val fourthImage = measureables.getOrNull(3)?.measure(
+            constraints.copy(maxWidth = imagesWidth, maxHeight = imagesWidth / 2)
+        )
+
+        layout(
+            width = constraints.maxWidth,
+            height = constraints.maxWidth * 2 / 3
+        ) {
+            firstImage?.placeRelative(x = 0, y = 0)
+            secondImage?.placeRelative(
+                x = when (imageCount) {
+                    3, 4 -> 0
+                    else -> imagesWidth
+                },
+                y = when (imageCount) {
+                    3, 4 -> imagesWidth / 2
+                    else -> 0
+                }
+            )
+            thirdImage?.placeRelative(x = imagesWidth, y = 0)
+            fourthImage?.placeRelative(x = imagesWidth, y = imagesWidth / 2)
         }
     }
 }

--- a/core/ui/src/main/java/com/core/ui/image/ImageList.kt
+++ b/core/ui/src/main/java/com/core/ui/image/ImageList.kt
@@ -116,15 +116,15 @@ fun HarooGridImages(
     images: List<ImageUiModel>, // 이미지 정보 리스트
     content: @Composable (ImageUiModel) -> Unit
 ) {
-    val imageCount = remember(images.size) { images.size }
-
     Layout(
         modifier = modifier.clip(shape),
         content = { images.forEach { content(it) } }
     ) { measureables, constraints ->
-        val imagesWidth = constraints.maxWidth / (if (imageCount >= 2) 2 else 1)
+        val imageCount = images.size
+        val imagesWidth = if (imageCount == 1) constraints.maxWidth else (constraints.maxWidth / 2)
         val firstImage = measureables.getOrNull(0)?.measure(
             constraints.copy(
+                minWidth = imagesWidth,
                 maxWidth = imagesWidth,
                 maxHeight = when (imageCount) {
                     1, 3, 4 -> imagesWidth / 2

--- a/core/ui/src/main/java/com/core/ui/image/ImageList.kt
+++ b/core/ui/src/main/java/com/core/ui/image/ImageList.kt
@@ -156,7 +156,7 @@ fun HarooGridImages(
 
         layout(
             width = constraints.maxWidth,
-            height = constraints.maxWidth * 2 / 3
+            height = constraints.maxWidth / 2
         ) {
             firstImage?.placeRelative(x = 0, y = 0)
             secondImage?.placeRelative(

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -9,19 +9,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
-import com.core.designsystem.components.HarooButton
-import com.core.designsystem.components.HarooImage
-import com.core.designsystem.components.HarooSurface
-import com.core.designsystem.components.HarooVerticalDivider
+import com.core.designsystem.components.*
 import com.core.designsystem.modifiers.noRippleClickable
 import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.PostUiModel
 import com.core.ui.date.ColumnDayAndDate
 import com.core.ui.image.AsyncImageList
+import com.core.ui.image.HarooGridImages
 import com.core.ui.tag.TagChip
 import java.time.LocalDate
 
@@ -237,5 +236,141 @@ fun LinearPostItem(
  * @use MonthlyScreen
  */
 @Composable
-fun GridPostItem() {
+fun GridPostItem(
+    date: LocalDate,
+    modifier: Modifier = Modifier,
+    contentColor: Color = LocalContentColor.current,
+    post: PostUiModel?, // 해당 일의 Post 정보
+) {
+    Layout(
+        modifier = modifier,
+        content = {
+            HarooVerticalDivider(
+                modifier = Modifier.layoutId("Line"),
+                dash = 0f
+            )
+            Canvas(modifier = Modifier.layoutId("Dot")) {
+                drawCircle(contentColor)
+            }
+            ColumnDayAndDate(
+                modifier = Modifier.layoutId("Day"),
+                date = date,
+                dayTextStyle = MaterialTheme.typography.subtitle1,
+                dateTextStyle = MaterialTheme.typography.body1
+            )
+            if (post != null) {
+                HarooGridImages(
+                    modifier = Modifier.layoutId("Images"),
+                    images = post.images,
+                    content = {
+                        HarooImage(
+                            shape = RectangleShape,
+                            imageType = ImageType.AsyncImage(image = it)
+                        )
+                    }
+                )
+                IconButton(
+                    modifier = Modifier
+                        .layoutId("DelBtn")
+                        .size(20.dp),
+                    onClick = { }
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = "back"
+                    )
+                }
+                if (post.tags.isNotEmpty()) {
+                    post.tags.forEach { tag ->
+                        TagChip(
+                            modifier = Modifier.layoutId("Tag"),
+                            name = "#${tag.name}",
+                            onClick = {}
+                        )
+                    }
+                    TagChip(
+                        modifier = Modifier.layoutId("Ellipse"),
+                        name = "...",
+                        onClick = {}
+                    )
+                }
+            } else {
+                HarooButton(
+                    modifier = Modifier.layoutId("AddBtn"),
+                    onClick = { }
+                ) {
+                    Text(text = "추가")
+                }
+            }
+        },
+    ) { measureables, constraints ->
+        val dotSize = 15
+        val paddingLineAndDay = 20
+        val paddingDayAndImages = 23
+        val paddingImagesAndTags = 12
+        val paddingTags = 4
+
+        val day = measureables.find { it.layoutId == "Day" }!!.measure(constraints)
+        val delBtn = measureables.find { it.layoutId == "DelBtn" }?.measure(constraints)
+        val addBtn = measureables.find { it.layoutId == "AddBtn" }?.measure(constraints)
+        val tags = measureables.filter { it.layoutId == "Tag" }.map { it.measure(constraints) }
+
+        val imageWidth = constraints.maxWidth - (paddingLineAndDay + day.width + paddingDayAndImages)
+        val images = measureables.find { it.layoutId == "Images" }?.measure(
+            constraints.copy(maxWidth = imageWidth)
+        )
+
+        val tagHeight = tags.firstOrNull()?.height ?: 0
+        var height = day.height + 26.dp.roundToPx()
+        if (post != null) height += (images?.height ?: 0) + tagHeight + paddingImagesAndTags
+        val line = measureables.find { it.layoutId == "Line" }!!.measure(
+            Constraints(minHeight = height, maxHeight = height)
+        )
+        val dot = measureables.find { it.layoutId == "Dot" }!!.measure(
+            Constraints(
+                minWidth = dotSize, maxWidth = dotSize,
+                minHeight = dotSize, maxHeight = dotSize
+            )
+        )
+        val ellipse = measureables.find { it.layoutId == "Ellipse" }?.measure(constraints)
+
+        val dayX = paddingLineAndDay
+        val imagesX = dayX + day.width + paddingDayAndImages
+        val imagesY = day.height
+        val tagsListEndX = imagesX + (images?.width ?: 0)
+        val tagsListY = imagesY + (images?.height ?: 0) + paddingImagesAndTags
+        layout(
+            constraints.maxWidth,
+            height
+        ) {
+            line.placeRelative(x = 0, y = 0)
+            dot.placeRelative(
+                x = -dot.width / 2,
+                y = (day.height / 2) - dot.height / 2
+            )
+            day.placeRelative(x = dayX, y = 0)
+            images?.placeRelative(
+                x = imagesX, y = imagesY
+            )
+            delBtn?.placeRelative(
+                x = constraints.maxWidth - delBtn.width,
+                y = day.height / 2 - delBtn.height / 2
+            )
+            addBtn?.placeRelative(
+                x = constraints.maxWidth - addBtn.width,
+                y = (day.height / 2) - addBtn.height / 2
+            )
+            var x = imagesX
+            var isOver = false
+            tags.forEach {
+                if (x + it.width >= tagsListEndX) {
+                    isOver = true
+                    return@forEach
+                }
+                it.placeRelative(x = x, y = tagsListY)
+                x += it.width + paddingTags
+            }
+            if (isOver) ellipse?.placeRelative(x = x + paddingTags, y = tagsListY)
+        }
+    }
 }

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -1,15 +1,15 @@
 package com.core.ui.post
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
 import com.core.designsystem.components.HarooButton
 import com.core.designsystem.components.HarooImage
 import com.core.designsystem.components.HarooSurface
@@ -59,7 +59,6 @@ fun SimplePostItem(
                 date = date,
                 dateTextColor = HarooTheme.colors.text.copy(alpha = 0.5f)
             )
-
             if (post != null) {
                 AsyncImageList(
                     modifier = Modifier
@@ -89,7 +88,55 @@ fun SimplePostItem(
  * @use MonthlyScreen
  */
 @Composable
-fun LinearPostItem() {
+fun LinearPostItem(
+    date: LocalDate,
+    modifier: Modifier = Modifier,
+    contentColor: Color = LocalContentColor.current,
+    post: PostUiModel?, // 해당 일의 Post 정보
+) {
+    ConstraintLayout(
+        modifier = modifier.fillMaxWidth().padding(bottom = 26.dp)
+    ) {
+        val (day, images, tags, addBtn, delBtn) = createRefs()
+        ColumnDayAndDate(
+            modifier = Modifier.constrainAs(day) {
+                top.linkTo(parent.top)
+                start.linkTo(parent.start)
+            },
+            date = date,
+            dayTextStyle = MaterialTheme.typography.subtitle1,
+            dateTextStyle = MaterialTheme.typography.body1
+        )
+
+        // 게시글이 있는 경우
+        if (post != null) {
+            AsyncImageList(
+                modifier = Modifier
+                    .constrainAs(images) {
+                        top.linkTo(parent.top)
+                        start.linkTo(day.end)
+                    }
+                    .noRippleClickable {}
+                    .padding(start = 20.dp, end = 8.dp),
+                images = post.images,
+                imageCount = 4,
+                space = 4.dp
+            ) { image ->
+                HarooImage(imageType = image)
+            }
+        } else {
+            HarooButton(
+                modifier = Modifier.constrainAs(addBtn) {
+                    end.linkTo(parent.end)
+                    top.linkTo(day.top)
+                    bottom.linkTo(day.bottom)
+                },
+                onClick = { }
+            ) {
+                Text(text = "추가")
+            }
+        }
+    }
 }
 
 /**

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -238,6 +238,8 @@ fun LinearPostItem(
 @Composable
 fun GridPostItem(
     date: LocalDate,
+    isFirstItem: Boolean = false,
+    isLastItem: Boolean = false,
     modifier: Modifier = Modifier,
     contentColor: Color = LocalContentColor.current,
     post: PostUiModel?, // 해당 일의 Post 정보
@@ -323,8 +325,9 @@ fun GridPostItem(
         val tagHeight = tags.firstOrNull()?.height ?: 0
         var height = day.height + 26.dp.roundToPx()
         if (post != null) height += (images?.height ?: 0) + tagHeight + paddingImagesAndTags
-        val line = measureables.find { it.layoutId == "Line" }!!.measure(
-            Constraints(minHeight = height, maxHeight = height)
+        val lineHeight = if (isFirstItem) height - day.height / 2 else if (isLastItem) day.height / 2 else height
+        val line = measureables.find { it.layoutId == "Line" }?.measure(
+            Constraints(minHeight = lineHeight, maxHeight = lineHeight)
         )
         val dot = measureables.find { it.layoutId == "Dot" }!!.measure(
             Constraints(
@@ -335,6 +338,7 @@ fun GridPostItem(
         val ellipse = measureables.find { it.layoutId == "Ellipse" }?.measure(constraints)
 
         val dayX = paddingLineAndDay
+        val lineY = if (isFirstItem) day.height / 2 else 0
         val imagesX = dayX + day.width + paddingDayAndImages
         val imagesY = day.height
         val tagsListEndX = imagesX + (images?.width ?: 0)
@@ -343,7 +347,7 @@ fun GridPostItem(
             constraints.maxWidth,
             height
         ) {
-            line.placeRelative(x = 0, y = 0)
+            line?.placeRelative(x = 0, y = lineY)
             dot.placeRelative(
                 x = -dot.width / 2,
                 y = (day.height / 2) - dot.height / 2

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import com.core.designsystem.components.*
@@ -296,6 +297,12 @@ fun GridPostItem(
                         onClick = {}
                     )
                 }
+                Text(
+                    modifier = Modifier.layoutId("Content"),
+                    text = post.content,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
             } else {
                 HarooButton(
                     modifier = Modifier.layoutId("AddBtn"),
@@ -311,6 +318,7 @@ fun GridPostItem(
         val paddingDayAndImages = 23
         val paddingImagesAndTags = 12
         val paddingTags = 4
+        val paddingTagsAndContent = 16
 
         val day = measureables.find { it.layoutId == "Day" }!!.measure(constraints)
         val delBtn = measureables.find { it.layoutId == "DelBtn" }?.measure(constraints)
@@ -321,10 +329,21 @@ fun GridPostItem(
         val images = measureables.find { it.layoutId == "Images" }?.measure(
             constraints.copy(maxWidth = imageWidth)
         )
+        val content = measureables.find { it.layoutId == "Content" }?.measure(
+            constraints.copy(maxWidth = images?.width ?: constraints.maxWidth)
+        )
 
         val tagHeight = tags.firstOrNull()?.height ?: 0
+        val dayX = paddingLineAndDay
+        val lineY = if (isFirstItem) day.height / 2 else 0
+        val imagesX = dayX + day.width + paddingDayAndImages
+        val imagesY = day.height
+        val tagsListEndX = imagesX + (images?.width ?: 0)
+        val tagsListY = imagesY + (images?.height ?: 0) + paddingImagesAndTags
+        val contentY = tagsListY + tagHeight + paddingTagsAndContent
+
         var height = day.height + 26.dp.roundToPx()
-        if (post != null) height += (images?.height ?: 0) + tagHeight + paddingImagesAndTags
+        if (post != null) height += contentY + (content?.measuredHeight ?: 0)
         val lineHeight = if (isFirstItem) height - day.height / 2 else if (isLastItem) day.height / 2 else height
         val line = measureables.find { it.layoutId == "Line" }?.measure(
             Constraints(minHeight = lineHeight, maxHeight = lineHeight)
@@ -337,12 +356,6 @@ fun GridPostItem(
         )
         val ellipse = measureables.find { it.layoutId == "Ellipse" }?.measure(constraints)
 
-        val dayX = paddingLineAndDay
-        val lineY = if (isFirstItem) day.height / 2 else 0
-        val imagesX = dayX + day.width + paddingDayAndImages
-        val imagesY = day.height
-        val tagsListEndX = imagesX + (images?.width ?: 0)
-        val tagsListY = imagesY + (images?.height ?: 0) + paddingImagesAndTags
         layout(
             constraints.maxWidth,
             height
@@ -375,6 +388,7 @@ fun GridPostItem(
                 x += it.width + paddingTags
             }
             if (isOver) ellipse?.placeRelative(x = x + paddingTags, y = tagsListY)
+            content?.placeRelative(x = imagesX, y = contentY)
         }
     }
 }

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -1,5 +1,6 @@
 package com.core.ui.post
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
@@ -8,16 +9,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
 import com.core.designsystem.components.HarooButton
 import com.core.designsystem.components.HarooImage
 import com.core.designsystem.components.HarooSurface
+import com.core.designsystem.components.HarooVerticalDivider
 import com.core.designsystem.modifiers.noRippleClickable
 import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.PostUiModel
 import com.core.ui.date.ColumnDayAndDate
 import com.core.ui.image.AsyncImageList
+import com.core.ui.tag.TagChip
 import java.time.LocalDate
 
 /**
@@ -94,47 +99,135 @@ fun LinearPostItem(
     contentColor: Color = LocalContentColor.current,
     post: PostUiModel?, // 해당 일의 Post 정보
 ) {
-    ConstraintLayout(
-        modifier = modifier.fillMaxWidth().padding(bottom = 26.dp)
-    ) {
-        val (day, images, tags, addBtn, delBtn) = createRefs()
-        ColumnDayAndDate(
-            modifier = Modifier.constrainAs(day) {
-                top.linkTo(parent.top)
-                start.linkTo(parent.start)
-            },
-            date = date,
-            dayTextStyle = MaterialTheme.typography.subtitle1,
-            dateTextStyle = MaterialTheme.typography.body1
-        )
-
-        // 게시글이 있는 경우
-        if (post != null) {
-            AsyncImageList(
-                modifier = Modifier
-                    .constrainAs(images) {
-                        top.linkTo(parent.top)
-                        start.linkTo(day.end)
+    Layout(
+        modifier = modifier,
+        content = {
+            HarooVerticalDivider(
+                modifier = Modifier.layoutId("Line"),
+                dash = 0f
+            )
+            Canvas(modifier = Modifier.layoutId("Dot")) {
+                drawCircle(contentColor)
+            }
+            ColumnDayAndDate(
+                modifier = Modifier.layoutId("Day"),
+                date = date,
+                dayTextStyle = MaterialTheme.typography.subtitle1,
+                dateTextStyle = MaterialTheme.typography.body1
+            )
+            if (post != null) {
+                AsyncImageList(
+                    modifier = Modifier.layoutId("Images"),
+                    images = post.images,
+                    imageCount = 4,
+                    space = 8.dp,
+                    content = { HarooImage(imageType = it) }
+                )
+                IconButton(
+                    modifier = Modifier
+                        .layoutId("DelBtn")
+                        .size(20.dp),
+                    onClick = { }
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = "back"
+                    )
+                }
+                if (post.tags.isNotEmpty()) {
+                    post.tags.forEach { tag ->
+                        TagChip(
+                            modifier = Modifier.layoutId("Tag"),
+                            name = "#${tag.name}",
+                            onClick = {}
+                        )
                     }
-                    .noRippleClickable {}
-                    .padding(start = 20.dp, end = 8.dp),
-                images = post.images,
-                imageCount = 4,
-                space = 4.dp
-            ) { image ->
-                HarooImage(imageType = image)
+                    TagChip(
+                        modifier = Modifier.layoutId("Ellipse"),
+                        name = "...",
+                        onClick = {}
+                    )
+                }
+            } else {
+                HarooButton(
+                    modifier = Modifier.layoutId("AddBtn"),
+                    onClick = { }
+                ) {
+                    Text(text = "추가")
+                }
             }
-        } else {
-            HarooButton(
-                modifier = Modifier.constrainAs(addBtn) {
-                    end.linkTo(parent.end)
-                    top.linkTo(day.top)
-                    bottom.linkTo(day.bottom)
-                },
-                onClick = { }
-            ) {
-                Text(text = "추가")
+        },
+    ) { measureables, constraints ->
+        val dotSize = 15
+        val paddingLineAndDay = 20
+        val paddingDayAndImages = 23
+        val paddingImagesAndDelBtn = 23
+        val paddingImagesAndTags = 12
+        val paddingTags = 4
+
+        val day = measureables.find { it.layoutId == "Day" }!!.measure(constraints)
+
+        val delBtn = measureables.find { it.layoutId == "DelBtn" }?.measure(constraints)
+        val addBtn = measureables.find { it.layoutId == "AddBtn" }?.measure(constraints)
+
+        val imageWidth = constraints.maxWidth - (paddingLineAndDay + day.width +
+                paddingDayAndImages + paddingImagesAndDelBtn + (delBtn?.width ?: 0))
+        val images = measureables.find { it.layoutId == "Images" }?.measure(
+            constraints.copy(maxWidth = imageWidth)
+        )
+        val tags = measureables.filter { it.layoutId == "Tag" }.map {
+            it.measure(constraints)
+        }
+
+        val tagHeight = tags.firstOrNull()?.height ?: 0
+        val height = (
+                if (post == null) day.height
+                else images!!.height + tagHeight + paddingImagesAndTags) + 26.dp.roundToPx()
+        val line = measureables.find { it.layoutId == "Line" }!!.measure(
+            Constraints(minHeight = height, maxHeight = height)
+        )
+        val dot = measureables.find { it.layoutId == "Dot" }!!.measure(
+            Constraints(
+                minWidth = dotSize, maxWidth = dotSize,
+                minHeight = dotSize, maxHeight = dotSize
+            )
+        )
+        val ellipse = measureables.find { it.layoutId == "Ellipse" }?.measure(constraints)
+
+        val dayX = paddingLineAndDay
+        val imagesX = dayX + day.width + paddingDayAndImages
+        val tagsListEndX = imagesX + (images?.width ?: 0)
+        val tagsListY = (images?.height ?: 0) + paddingImagesAndTags
+        layout(
+            constraints.maxWidth,
+            height
+        ) {
+            line.placeRelative(x = 0, y = 0)
+            dot.placeRelative(
+                x = -dot.width / 2,
+                y = (day.height / 2) - dot.height / 2
+            )
+            day.placeRelative(x = dayX, y = 0)
+            images?.placeRelative(x = imagesX, y = 0)
+            delBtn?.placeRelative(
+                x = constraints.maxWidth - delBtn.width,
+                y = (images?.height ?: 0) / 2 - delBtn.height / 2
+            )
+            addBtn?.placeRelative(
+                x = constraints.maxWidth - addBtn.width,
+                y = (day.height / 2) - addBtn.height / 2
+            )
+            var x = imagesX
+            var isOver = false
+            tags.forEach {
+                if (x + it.width >= tagsListEndX) {
+                    isOver = true
+                    return@forEach
+                }
+                it.placeRelative(x = x, y = tagsListY)
+                x += it.width + paddingTags
             }
+            if (isOver) ellipse?.placeRelative(x = x + paddingTags, y = tagsListY)
         }
     }
 }

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -96,6 +96,8 @@ fun SimplePostItem(
 fun LinearPostItem(
     date: LocalDate,
     modifier: Modifier = Modifier,
+    isFirstItem: Boolean = false,
+    isLastItem: Boolean = false,
     contentColor: Color = LocalContentColor.current,
     post: PostUiModel?, // 해당 일의 Post 정보
 ) {
@@ -183,8 +185,9 @@ fun LinearPostItem(
         val height = (
                 if (post == null) day.height
                 else images!!.height + tagHeight + paddingImagesAndTags) + 26.dp.roundToPx()
+        val lineHeight = if (isFirstItem) height - day.height / 2 else if (isLastItem) day.height / 2 else height
         val line = measureables.find { it.layoutId == "Line" }!!.measure(
-            Constraints(minHeight = height, maxHeight = height)
+            Constraints(minHeight = lineHeight, maxHeight = lineHeight)
         )
         val dot = measureables.find { it.layoutId == "Dot" }!!.measure(
             Constraints(
@@ -195,6 +198,7 @@ fun LinearPostItem(
         val ellipse = measureables.find { it.layoutId == "Ellipse" }?.measure(constraints)
 
         val dayX = paddingLineAndDay
+        val lineY = if (isFirstItem) day.height / 2 else 0
         val imagesX = dayX + day.width + paddingDayAndImages
         val tagsListEndX = imagesX + (images?.width ?: 0)
         val tagsListY = (images?.height ?: 0) + paddingImagesAndTags
@@ -202,7 +206,7 @@ fun LinearPostItem(
             constraints.maxWidth,
             height
         ) {
-            line.placeRelative(x = 0, y = 0)
+            line.placeRelative(x = 0, y = lineY)
             dot.placeRelative(
                 x = -dot.width / 2,
                 y = (day.height / 2) - dot.height / 2

--- a/core/ui/src/main/java/com/core/ui/tag/Tag.kt
+++ b/core/ui/src/main/java/com/core/ui/tag/Tag.kt
@@ -74,10 +74,12 @@ fun TagContainer(
 
 @Composable
 fun TagChip(
+    modifier: Modifier = Modifier,
     name: String,
     onClick: () -> Unit
 ) {
     HarooChip(
+        modifier = modifier,
         onClick = onClick,
         border = null,
         alpha = 0.25f

--- a/feature/monthly/build.gradle.kts
+++ b/feature/monthly/build.gradle.kts
@@ -6,3 +6,7 @@ plugins {
 android {
     namespace = "com.feature.monthly"
 }
+
+dependencies {
+    implementation(project(":core:ui"))
+}

--- a/feature/monthly/build.gradle.kts
+++ b/feature/monthly/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id ("haroo.android.library")
     id("haroo.android.library.compose")
+    id("haroo.android.hilt")
 }
 
 android {
@@ -11,4 +12,5 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:designsystem"))
     implementation(project(":core:model"))
+    implementation(project(":core:domain"))
 }

--- a/feature/monthly/build.gradle.kts
+++ b/feature/monthly/build.gradle.kts
@@ -9,4 +9,6 @@ android {
 
 dependencies {
     implementation(project(":core:ui"))
+    implementation(project(":core:designsystem"))
+    implementation(project(":core:model"))
 }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.core.designsystem.components.HarooHeader
 import com.core.designsystem.components.HarooRadioButton
 import com.core.designsystem.components.HarooSurface
 import com.core.designsystem.components.HarooVerticalDivider
@@ -85,11 +86,11 @@ fun MonthlyScreen(
         CompositionLocalProvider(
             LocalContentColor provides HarooTheme.colors.text
         ) {
+            HarooHeader(title = "하루네컷", onBackPressed = {})
             MonthlyHeader(
                 modifier = Modifier.padding(bottom = 26.dp),
                 date = today,
                 posts = groupedPost,
-                heightProvider = { toolbarState.height },
                 progressProvider = { toolbarState.progress }
             )
 
@@ -121,6 +122,8 @@ fun MonthlyScreen(
                                 )
                             } else {
                                 LinearPostItem(
+                                    isFirstItem = it == 0,
+                                    isLastItem = it == dateCount - 1,
                                     date = today.atDay(it + 1),
                                     post = groupedPost[day]
                                 )
@@ -137,10 +140,9 @@ fun MonthlyScreen(
 fun MonthlyHeader(
     date: YearMonth,
     modifier: Modifier = Modifier,
-    verticalSpace: Dp = 4.dp,
-    horizontalSpace: Dp = 4.dp,
+    verticalSpace: Dp = 8.dp,
+    horizontalSpace: Dp = 8.dp,
     posts: Map<LocalDate, PostUiModel>,
-    heightProvider: () -> Float,
     progressProvider: () -> Float
 ) {
     Layout(

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -1,7 +1,92 @@
 package com.feature.monthly
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.core.designsystem.components.HarooVerticalDivider
+import com.core.designsystem.theme.HarooTheme
+import com.core.model.feature.PostUiModel
+import com.core.ui.date.RowMonthAndName
+import java.time.LocalDate
+import java.time.YearMonth
 
 @Composable
 fun MonthlyScreen() {
+    val today = YearMonth.now()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .imePadding()
+            .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground)),
+    ) {
+        MonthlyHeader(date = today, posts = emptyMap())
+    }
+}
+
+@Composable
+fun MonthlyHeader(
+    date: YearMonth,
+    modifier: Modifier = Modifier,
+    verticalSpace: Dp = 4.dp,
+    horizontalSpace: Dp = 4.dp,
+    posts: Map<LocalDate, PostUiModel>
+) {
+    Column(
+        modifier = modifier
+    ) {
+        CompositionLocalProvider(
+            LocalContentColor provides HarooTheme.colors.text
+        ) {
+            RowMonthAndName(
+                modifier = Modifier.padding(16.dp),
+                date = date
+            )
+//        Calendar(
+//            space = verticalSpace,
+//            currentMonth = date,
+//            dayContent = {
+//                DateWithImage(
+//                    modifier = Modifier.padding(horizontal = horizontalSpace),
+//                    state = it,
+//                    image = posts[it.date]?.images?.firstOrNull()
+//                )
+//            }
+//        )
+            Row(
+                modifier = Modifier.fillMaxWidth().height(50.dp),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                MonthlyCountContainer(name = "전체일수", count = date.lengthOfMonth())
+                HarooVerticalDivider(modifier = Modifier.padding(horizontal = 30.dp))
+                MonthlyCountContainer(name = "기록일수", count = posts.size)
+                HarooVerticalDivider(modifier = Modifier.padding(horizontal = 30.dp))
+                MonthlyCountContainer(name = "이미지", count = posts.values.sumOf { it.images.size })
+            }
+        }
+    }
+}
+
+@Composable
+fun MonthlyCountContainer(
+    name: String, // info name
+    count: Int // info 개수
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(text = name, style = MaterialTheme.typography.body1)
+        Text(text = count.toString(), style = MaterialTheme.typography.body1)
+    }
 }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -2,35 +2,90 @@ package com.feature.monthly
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
 import com.core.designsystem.components.HarooVerticalDivider
+import com.core.designsystem.components.calendar.Calendar
 import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.PostUiModel
+import com.core.ui.date.DateWithImage
 import com.core.ui.date.RowMonthAndName
+import com.feature.monthly.ui.ToolbarState
+import com.feature.monthly.ui.rememberToolbarState
 import java.time.LocalDate
 import java.time.YearMonth
 
 @Composable
 fun MonthlyScreen() {
     val today = YearMonth.now()
+    val dateCount = remember(today) { today.lengthOfMonth() }
+
+    // Toolbar 가능 높이
+    val toolbarHeightRange = with(LocalDensity.current) {
+        60.dp.roundToPx()..150.dp.roundToPx()
+    }
+
+    val toolbarState = rememberToolbarState(toolbarHeightRange = toolbarHeightRange)
+    val listState = rememberLazyListState()
+
+    val nestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            // Scroll 이 발생하였을 떄
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                toolbarState.scrollTopLimitReached =
+                    listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
+                toolbarState.scrollOffset = toolbarState.scrollOffset - available.y
+                return Offset(0f, toolbarState.consumed)
+            }
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
             .navigationBarsPadding()
             .imePadding()
-            .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground)),
+            .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground))
+            .nestedScroll(nestedScrollConnection),
     ) {
-        MonthlyHeader(date = today, posts = emptyMap())
+        CompositionLocalProvider(
+            LocalContentColor provides HarooTheme.colors.text
+        ) {
+            MonthlyHeader(
+                date = today,
+                posts = emptyMap(),
+                heightProvider = { toolbarState.height },
+                progressProvider = { toolbarState.progress })
+            LazyColumn(
+                state = listState
+            ) {
+                items(count = dateCount) {
+                    Text(text = "day $it", style = MaterialTheme.typography.h2)
+                }
+            }
+        }
     }
 }
 
@@ -40,31 +95,44 @@ fun MonthlyHeader(
     modifier: Modifier = Modifier,
     verticalSpace: Dp = 4.dp,
     horizontalSpace: Dp = 4.dp,
-    posts: Map<LocalDate, PostUiModel>
+    posts: Map<LocalDate, PostUiModel>,
+    heightProvider: () -> Float,
+    progressProvider: () -> Float
 ) {
-    Column(
-        modifier = modifier
-    ) {
-        CompositionLocalProvider(
-            LocalContentColor provides HarooTheme.colors.text
-        ) {
+    Layout(
+        modifier = modifier,
+        content = {
             RowMonthAndName(
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier
+                    .layoutId("Date")
+                    .padding(16.dp),
                 date = date
             )
-//        Calendar(
-//            space = verticalSpace,
-//            currentMonth = date,
-//            dayContent = {
-//                DateWithImage(
-//                    modifier = Modifier.padding(horizontal = horizontalSpace),
-//                    state = it,
-//                    image = posts[it.date]?.images?.firstOrNull()
-//                )
-//            }
-//        )
+            Calendar(
+                modifier = Modifier
+                    .layoutId("Calendar")
+                    .graphicsLayer {
+                        val progress = progressProvider()
+                        alpha = progress
+                        scaleY = progress
+                        translationY = (progressProvider() - 1) * (size.height / 2)
+                    },
+                space = verticalSpace,
+                currentMonth = date,
+                dayContent = {
+                    DateWithImage(
+                        modifier = Modifier.padding(horizontal = horizontalSpace),
+                        state = it,
+                        image = posts[it.date]?.images?.firstOrNull()
+                    )
+                }
+            )
             Row(
-                modifier = Modifier.fillMaxWidth().height(50.dp),
+                modifier = Modifier
+                    .layoutId("Info")
+                    .graphicsLayer { alpha = 1 - progressProvider() }
+                    .fillMaxWidth()
+                    .height(50.dp),
                 horizontalArrangement = Arrangement.Center
             ) {
                 MonthlyCountContainer(name = "전체일수", count = date.lengthOfMonth())
@@ -73,6 +141,30 @@ fun MonthlyHeader(
                 HarooVerticalDivider(modifier = Modifier.padding(horizontal = 30.dp))
                 MonthlyCountContainer(name = "이미지", count = posts.values.sumOf { it.images.size })
             }
+        }
+    ) { measureables, constraints ->
+        val progress = progressProvider()
+        val date = measureables.find { it.layoutId == "Date" }!!.measure(constraints)
+        val calendar = measureables.find { it.layoutId == "Calendar" }!!.measure(constraints)
+        val info = measureables.find { it.layoutId == "Info" }!!.measure(constraints)
+
+        val height = lerp(
+            start = (date.height + info.height).toDp(),
+            stop = (date.height + calendar.height).toDp(),
+            fraction = progress
+        )
+        val dateX = lerp(
+            start = ((constraints.maxWidth - date.width) / 2).toDp(),
+            stop = 0f.toDp(),
+            fraction = progress
+        )
+        layout(
+            constraints.maxWidth,
+            height = height.roundToPx()
+        ) {
+            date.placeRelative(x = dateX.roundToPx(), y = 0)
+            calendar.placeRelative(x = 0, y = date.height)
+            info.placeRelative(x = 0, y = date.height)
         }
     }
 }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -23,6 +24,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.core.designsystem.components.HarooRadioButton
 import com.core.designsystem.components.HarooSurface
 import com.core.designsystem.components.HarooVerticalDivider
 import com.core.designsystem.components.calendar.Calendar
@@ -30,6 +32,7 @@ import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.PostUiModel
 import com.core.ui.date.DateWithImage
 import com.core.ui.date.RowMonthAndName
+import com.core.ui.post.GridPostItem
 import com.core.ui.post.LinearPostItem
 import com.feature.monthly.ui.rememberToolbarState
 import java.time.LocalDate
@@ -68,6 +71,7 @@ fun MonthlyScreen(
             }
         }
     }
+    val listType = rememberSaveable { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -82,6 +86,7 @@ fun MonthlyScreen(
             LocalContentColor provides HarooTheme.colors.text
         ) {
             MonthlyHeader(
+                modifier = Modifier.padding(bottom = 26.dp),
                 date = today,
                 posts = groupedPost,
                 heightProvider = { toolbarState.height },
@@ -93,13 +98,34 @@ fun MonthlyScreen(
                 shape = MaterialTheme.shapes.large,
                 alpha = 0.08f
             ) {
-                LazyColumn(
-                    state = listState,
-                    contentPadding = PaddingValues(horizontal = 36.dp)
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    items(count = dateCount) {
-                        val day = today.atDay(it + 1)
-                        LinearPostItem(date = today.atDay(it + 1), post = groupedPost[day])
+                    HarooRadioButton(
+                        modifier = Modifier.padding(16.dp),
+                        selected = listType.value,
+                        onSelected = { listType.value = listType.value.not() }
+                    )
+                    LazyColumn(
+                        state = listState,
+                        contentPadding = PaddingValues(horizontal = 36.dp)
+                    ) {
+                        items(count = dateCount) {
+                            val day = today.atDay(it + 1)
+                            if (listType.value) {
+                                GridPostItem(
+                                    isFirstItem = it == 0,
+                                    isLastItem = it == dateCount - 1,
+                                    date = today.atDay(it + 1),
+                                    post = groupedPost[day]
+                                )
+                            } else {
+                                LinearPostItem(
+                                    date = today.atDay(it + 1),
+                                    post = groupedPost[day]
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -25,13 +24,13 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
+import com.core.designsystem.components.HarooSurface
 import com.core.designsystem.components.HarooVerticalDivider
 import com.core.designsystem.components.calendar.Calendar
 import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.PostUiModel
 import com.core.ui.date.DateWithImage
 import com.core.ui.date.RowMonthAndName
-import com.feature.monthly.ui.ToolbarState
 import com.feature.monthly.ui.rememberToolbarState
 import java.time.LocalDate
 import java.time.YearMonth
@@ -78,11 +77,18 @@ fun MonthlyScreen() {
                 posts = emptyMap(),
                 heightProvider = { toolbarState.height },
                 progressProvider = { toolbarState.progress })
-            LazyColumn(
-                state = listState
+
+            HarooSurface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.large,
+                alpha = 0.08f
             ) {
-                items(count = dateCount) {
-                    Text(text = "day $it", style = MaterialTheme.typography.h2)
+                LazyColumn(
+                    state = listState
+                ) {
+                    items(count = dateCount) {
+                        Text(text = "day $it", style = MaterialTheme.typography.h2)
+                    }
                 }
             }
         }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
@@ -1,0 +1,29 @@
+package com.feature.monthly
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.core.domain.post.GetPostByMonthUseCase
+import com.core.model.feature.PostUiModel
+import com.core.model.feature.toPostUiModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MonthlyViewModel @Inject constructor(
+    private val getPostByMonthUseCase: GetPostByMonthUseCase
+) : ViewModel() {
+
+    private val _posts = MutableStateFlow<List<PostUiModel>>(emptyList())
+    val posts: StateFlow<List<PostUiModel>> = _posts.asStateFlow()
+
+    fun init(year: Int, month: Int) {
+        viewModelScope.launch {
+            _posts.value = getPostByMonthUseCase(year, month).map { it.toPostUiModel() }
+            println(_posts.value)
+        }
+    }
+}

--- a/feature/monthly/src/main/java/com/feature/monthly/ui/ToolbarState.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/ui/ToolbarState.kt
@@ -1,0 +1,99 @@
+package com.feature.monthly.ui
+
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.mapSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+
+@Stable
+interface ToolbarState {
+    val height: Float
+    val progress: Float
+    val consumed: Float
+    var scrollTopLimitReached: Boolean
+    var scrollOffset: Float
+}
+
+abstract class ScrollFlagState(heightRange: IntRange) : ToolbarState {
+    init {
+        require(heightRange.first >= 0 && heightRange.last >= heightRange.first) {
+            "Illegal State 0 <= min height < max height"
+        }
+    }
+
+    protected val minHeight = heightRange.first
+    protected val maxHeight = heightRange.last
+    protected val rangeOfDiff = maxHeight - minHeight
+    protected var _consumed = 0f
+    protected abstract var _scrollOffset: Float
+
+    final override val height: Float
+        get() = (maxHeight - scrollOffset).coerceIn(minHeight.toFloat(), maxHeight.toFloat())
+
+    final override val progress: Float
+        get() = 1 - (maxHeight - height) / rangeOfDiff
+
+    final override val consumed: Float
+        get() = _consumed
+
+    final override var scrollTopLimitReached = true
+}
+
+/**
+ * Scroll 시 App bar 가 상단에 고정되는 Collapsed Toolbar 의 State
+ */
+class ExitUnitCollapsedState(
+    heightRange: IntRange,
+    scrollOffset: Float = 0f
+) : ScrollFlagState(heightRange) {
+    override var _scrollOffset by mutableStateOf(
+        value = scrollOffset.coerceIn(0f, rangeOfDiff.toFloat()),
+        policy = structuralEqualityPolicy()
+    )
+
+    /**
+     * Scroll 된 정도
+     * 즉, Toolbar 의 줄어든 길이
+     * 때문에 height = maxHeight - scrollOffset 입니다.
+     */
+    override var scrollOffset: Float
+        get() = _scrollOffset
+        set(value) {
+            if (scrollTopLimitReached) {
+                val oldOffset = _scrollOffset
+                _scrollOffset = value.coerceIn(0f, rangeOfDiff.toFloat())
+                _consumed = oldOffset - _scrollOffset
+            } else {
+                _consumed = 0f
+            }
+        }
+
+    companion object {
+        private const val MIN_HEIGHT = "MIN_HEIGHT"
+        private const val MAX_HEIGHT = "MAX_HEIGHT"
+        private const val SCROLL_OFFSET = "SCROLL_OFFSET"
+
+        val Saver: Saver<ExitUnitCollapsedState, *> = mapSaver(
+            save = {
+                mapOf(
+                    MIN_HEIGHT to it.minHeight,
+                    MAX_HEIGHT to it.maxHeight,
+                    SCROLL_OFFSET to it.scrollOffset
+                )
+            },
+            restore = {
+                ExitUnitCollapsedState(
+                    heightRange = (it[MIN_HEIGHT] as Int)..(it[MAX_HEIGHT] as Int),
+                    scrollOffset = it[SCROLL_OFFSET] as Float
+                )
+            }
+        )
+    }
+}
+
+@Composable
+fun rememberToolbarState(toolbarHeightRange: IntRange): ToolbarState {
+    return rememberSaveable(saver = ExitUnitCollapsedState.Saver) {
+        ExitUnitCollapsedState(toolbarHeightRange)
+    }
+}


### PR DESCRIPTION
#### 📌 내용
Monthly Screen의 기본 UI 완성하기

#### 🛠 Done
- [x] Monthly Screen 기본 Toolbar 만들기
- [x] Collapsing 되었을 때 기본 Toolbar 만들기
- [x] List Collapsing 구현하기
- [x] List(Post가 없는 경우) Component 만들기
- [x] List에 추가해서 Collapsing 구현하기
- [x] List(Post가 있는 경우) Component 만들기
- [x] Grid(Post가 있는 경우) Component 만들기
- [x] 이미지 개수에 따라 다르게 나오도록 Layout 구현하기
- [x] Grid 형태로 List에 추가해서 확인하기
- [x] Radio 버튼
- [x] Radio 버튼에 따라 리스트가 다르게 나오도록 처리
- [x] 기본 Header 추가

#### 🌹 추가 구현사항
- [x] Radio 버튼 Animation 추가

#### 🪴 UI
https://user-images.githubusercontent.com/22411296/232304544-904e90f5-e2fe-4e72-8557-399266900fc8.mp4

#### 이미지 개수에 따른 배치 변경
<img width="250" src="https://user-images.githubusercontent.com/22411296/232306697-f99a464a-b34d-4e13-9d38-5e08a8858d4d.jpeg"/>
<img width="250" src="https://user-images.githubusercontent.com/22411296/232306700-6b2ad56b-8782-4b10-8e49-a88bbdf50e0a.jpeg"/>
<img width="250" src="https://user-images.githubusercontent.com/22411296/232306703-d7a003db-6ba5-4f69-872f-c65c6c7f3779.jpeg"/>

#### 🏠 관련 Issue
Closed #34 