### PR TITLE
[FEAT] #36 Monthly Screen의 비지니스 로직

### DIFF
--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">하루네컷</string>
+</resources>

--- a/core/ui/src/main/java/com/core/ui/image/ImageList.kt
+++ b/core/ui/src/main/java/com/core/ui/image/ImageList.kt
@@ -134,6 +134,7 @@ fun HarooGridImages(
         )
         val secondImage = measureables.getOrNull(1)?.measure(
             constraints.copy(
+                minWidth = imagesWidth,
                 maxWidth = imagesWidth,
                 maxHeight = when (imageCount) {
                     3, 4 -> imagesWidth / 2
@@ -143,6 +144,7 @@ fun HarooGridImages(
         )
         val thirdImage = measureables.getOrNull(2)?.measure(
             constraints.copy(
+                minWidth = imagesWidth,
                 maxWidth = imagesWidth,
                 maxHeight = when (imageCount) {
                     3 -> imagesWidth
@@ -151,7 +153,9 @@ fun HarooGridImages(
             )
         )
         val fourthImage = measureables.getOrNull(3)?.measure(
-            constraints.copy(maxWidth = imagesWidth, maxHeight = imagesWidth / 2)
+            constraints.copy(
+                minWidth = imagesWidth, maxWidth = imagesWidth, maxHeight = imagesWidth / 2
+            )
         )
 
         layout(

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -100,6 +100,7 @@ fun LinearPostItem(
     isLastItem: Boolean = false,
     contentColor: Color = LocalContentColor.current,
     post: PostUiModel?, // 해당 일의 Post 정보
+    onRemovePost: (PostUiModel) -> Unit
 ) {
     Layout(
         modifier = modifier,
@@ -129,7 +130,7 @@ fun LinearPostItem(
                     modifier = Modifier
                         .layoutId("DelBtn")
                         .size(20.dp),
-                    onClick = { }
+                    onClick = { onRemovePost(post) }
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.Close,
@@ -248,6 +249,7 @@ fun GridPostItem(
     modifier: Modifier = Modifier,
     contentColor: Color = LocalContentColor.current,
     post: PostUiModel?, // 해당 일의 Post 정보
+    onRemovePost: (PostUiModel) -> Unit
 ) {
     Layout(
         modifier = modifier,
@@ -280,7 +282,7 @@ fun GridPostItem(
                     modifier = Modifier
                         .layoutId("DelBtn")
                         .size(20.dp),
-                    onClick = { }
+                    onClick = { onRemovePost(post) }
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.Close,

--- a/core/ui/src/main/java/com/core/ui/post/PostItem.kt
+++ b/core/ui/src/main/java/com/core/ui/post/PostItem.kt
@@ -1,0 +1,129 @@
+package com.core.ui.post
+
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.unit.Constraints
+
+enum class PostItemType(val isShowContent: Boolean) {
+    LINEAR(false), GRID(true)
+}
+
+abstract class PostItem(
+    val isPost: Boolean,
+    val isFirstItem: Boolean,
+    val isLastItem: Boolean
+) {
+    var maxWidth: Int = 0
+    var bottomPadding: Int = 0
+    lateinit var day: Placeable
+    lateinit var dot: Placeable
+    var delBtn: Placeable? = null
+    var addBtn: Placeable? = null
+    var images: Placeable? = null
+    lateinit var tags: List<Placeable>
+    var ellipse: Placeable? = null
+
+    abstract val imagesWidth: Int
+    abstract val postHeight: Int
+
+    open fun measurePolicy(measureables: List<Measurable>, constraints: Constraints, bottomPadding: Int = 0) {
+        maxWidth = constraints.maxWidth
+        this.bottomPadding = bottomPadding
+        day = measureables.find { it.layoutId == "Day" }!!.measure(constraints)
+        delBtn = measureables.find { it.layoutId == "DelBtn" }?.measure(constraints)
+        addBtn = measureables.find { it.layoutId == "AddBtn" }?.measure(constraints)
+        tags = measureables.filter { it.layoutId == "Tag" }.map { it.measure(constraints) }
+
+        images = measureables.find { it.layoutId == "Images" }?.measure(
+            constraints.copy(minWidth = imagesWidth, maxWidth = imagesWidth)
+        )
+        dot = measureables.find { it.layoutId == "Dot" }!!.measure(
+            constraints.copy(minWidth = dotSize, maxWidth = dotSize, minHeight = dotSize, maxHeight = dotSize)
+        )
+        ellipse = measureables.find { it.layoutId == "Ellipse" }?.measure(constraints)
+    }
+
+    val lineX get() = if (isFirstItem) day.height / 2 else 0
+    val dotX get() = -dotSize / 2
+    val dotY get() = (day.height - dotSize) / 2
+    val dayX get() = paddingLineAndDay
+
+    open val imageX get() = dayX + day.width + paddingDayAndImages
+    open val imageY = 0
+    open val addBtnX get() = maxWidth - (addBtn!!.width)
+    open val addBtnY get() = (day.height - addBtn!!.height) / 2
+    open val delBtnX get() = maxWidth - delBtn!!.width
+    open val delBtnY = 0
+    open val tagsY get() = imageY + (images?.height ?: 0) + paddingImagesAndTags
+    open val tagsListEndX get() = imageX + imagesWidth
+
+    open fun Placeable.PlacementScope.place() {}
+    fun placeExtraComponent(placementScope: Placeable.PlacementScope) {
+        placementScope.place()
+    }
+
+    companion object {
+        const val dotSize: Int = 15
+        const val paddingLineAndDay: Int = 20
+        const val paddingDayAndImages: Int = 23
+        const val paddingImagesAndTags: Int = 12
+        const val paddingTags: Int = 4
+        const val paddingImagesAndDelBtn = 23
+        const val paddingTagsAndContent = 32
+
+        fun providePostItem(
+            isPost: Boolean, isFirstItem: Boolean, isLastItem: Boolean,
+            postItemType: PostItemType
+        ): PostItem {
+            return when (postItemType) {
+                PostItemType.LINEAR -> LinearPostItem(isPost, isFirstItem, isLastItem)
+                PostItemType.GRID -> GridPostItem(isPost, isFirstItem, isLastItem)
+            }
+        }
+    }
+}
+
+class LinearPostItem(
+    isPost: Boolean,
+    isFirstItem: Boolean,
+    isLastItem: Boolean
+) : PostItem(isPost, isFirstItem, isLastItem) {
+    override val imagesWidth: Int
+        get() = maxWidth - (dayX + day.width + paddingDayAndImages + (delBtn?.width ?: 0) + paddingImagesAndDelBtn)
+    override val postHeight: Int
+        get() = bottomPadding + if (isPost) (images?.height ?: 0) + (tags.firstOrNull()?.height ?: 0) else day.height
+    override val delBtnY: Int
+        get() = ((images?.height ?: 0) - day.height) / 2
+}
+
+class GridPostItem(
+    isPost: Boolean,
+    isFirstItem: Boolean,
+    isLastItem: Boolean
+) : PostItem(isPost, isFirstItem, isLastItem) {
+    var content: Placeable? = null
+    private val contentX get() = imageX
+    private val contentY get() = tagsY + (tags.firstOrNull()?.height ?: 0) + paddingTagsAndContent
+
+    override val imagesWidth: Int
+        get() = maxWidth - (dayX + day.width + paddingDayAndImages)
+    override val postHeight: Int
+        get() = bottomPadding + day.height + if (isPost) contentY + (content?.height ?: 0) else 0
+    override val delBtnY: Int
+        get() = (day.height - delBtn!!.height) / 2
+
+    override val imageY: Int
+        get() = day.height
+
+    override fun measurePolicy(measureables: List<Measurable>, constraints: Constraints, bottomPadding: Int) {
+        super.measurePolicy(measureables, constraints, bottomPadding)
+        content = measureables.find { it.layoutId == "Content" }?.measure(
+            constraints.copy(maxWidth = imagesWidth)
+        )
+    }
+
+    override fun Placeable.PlacementScope.place() {
+        content?.placeRelative(x = contentX, y = contentY)
+    }
+}

--- a/core/ui/src/main/java/com/core/ui/toolbar/CollapsingToolbar.kt
+++ b/core/ui/src/main/java/com/core/ui/toolbar/CollapsingToolbar.kt
@@ -1,0 +1,37 @@
+package com.core.ui.toolbar
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+
+@Composable
+fun CollapsingToolbar(
+    modifier: Modifier = Modifier,
+    listState: LazyListState,
+    toolbarState: ToolbarState,
+    content: @Composable () -> Unit
+) {
+    val nestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                toolbarState.scrollTopLimitReached =
+                    listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
+                toolbarState.scrollOffset = toolbarState.scrollOffset - available.y
+                return Offset(x = 0f, y = toolbarState.consumed)
+            }
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .nestedScroll(nestedScrollConnection)
+    ) {
+        content()
+    }
+}

--- a/core/ui/src/main/java/com/core/ui/toolbar/ToolbarState.kt
+++ b/core/ui/src/main/java/com/core/ui/toolbar/ToolbarState.kt
@@ -1,9 +1,11 @@
-package com.feature.monthly.ui
+package com.core.ui.toolbar
 
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 
 @Stable
 interface ToolbarState {

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -118,14 +118,16 @@ fun MonthlyScreen(
                                     isFirstItem = it == 0,
                                     isLastItem = it == dateCount - 1,
                                     date = today.atDay(it + 1),
-                                    post = groupedPost[day]
+                                    post = groupedPost[day],
+                                    onRemovePost = monthlyViewModel::removePost
                                 )
                             } else {
                                 LinearPostItem(
                                     isFirstItem = it == 0,
                                     isLastItem = it == dateCount - 1,
                                     date = today.atDay(it + 1),
-                                    post = groupedPost[day]
+                                    post = groupedPost[day],
+                                    onRemovePost = monthlyViewModel::removePost
                                 )
                             }
                         }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -12,19 +12,21 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.core.designsystem.components.HarooHeader
 import com.core.designsystem.components.HarooRadioButton
 import com.core.designsystem.components.HarooSurface
 import com.core.designsystem.theme.HarooTheme
+import com.core.designsystem.util.getString
 import com.core.model.feature.PostUiModel
 import com.core.ui.post.GridPostItem
 import com.core.ui.post.LinearPostItem
 import com.core.ui.toolbar.CollapsingToolbar
+import com.feature.monthly.ui.Dimens
 import com.feature.monthly.ui.MonthlyHeader
 import java.time.LocalDate
 import java.time.YearMonth
+import com.core.designsystem.R
 
 @Composable
 fun MonthlyScreen(
@@ -59,9 +61,9 @@ fun MonthlyScreen(
         CompositionLocalProvider(
             LocalContentColor provides HarooTheme.colors.text
         ) {
-            HarooHeader(title = "하루네컷", onBackPressed = {})
+            HarooHeader(title = getString(id = R.string.app_name), onBackPressed = {})
             MonthlyHeader(
-                modifier = Modifier.padding(bottom = 26.dp),
+                modifier = Modifier.padding(bottom = Dimens.spaceBetweenHeaderAndBody),
                 date = monthlyScreenStateHolder.date,
                 posts = monthlyScreenStateHolder.groupedPost,
                 progressProvider = { monthlyScreenStateHolder.toolbarState.progress }
@@ -98,13 +100,13 @@ fun MonthlyBody(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             HarooRadioButton(
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier.padding(Dimens.paddingRadioBtn),
                 selected = listType,
                 onSelected = onChangeListType
             )
             LazyColumn(
                 state = lazyListState,
-                contentPadding = PaddingValues(horizontal = 36.dp)
+                contentPadding = PaddingValues(horizontal = Dimens.postListHorizontalPadding)
             ) {
                 items(count = dateCount) {
                     val day = date.atDay(it + 1)

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -55,12 +55,12 @@ fun MonthlyScreen(
             MonthlyHeader(
                 modifier = Modifier.padding(bottom = Dimens.spaceBetweenHeaderAndBody),
                 date = monthlyScreenStateHolder.date,
-                posts = monthlyScreenStateHolder.groupedPost,
+                posts = monthlyScreenStateHolder.posts.value,
                 progressProvider = { monthlyScreenStateHolder.toolbarState.progress }
             )
             MonthlyBody(
                 lazyListState = monthlyScreenStateHolder.lazyListState,
-                groupedPosts = monthlyScreenStateHolder.groupedPost,
+                groupedPosts = monthlyScreenStateHolder.posts.value,
                 listType = monthlyScreenStateHolder.listType.value,
                 date = monthlyScreenStateHolder.date,
                 dateCount = monthlyScreenStateHolder.dateCount,

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -3,85 +3,58 @@ package com.feature.monthly
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.layout.layoutId
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.lerp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.core.designsystem.components.HarooHeader
 import com.core.designsystem.components.HarooRadioButton
 import com.core.designsystem.components.HarooSurface
-import com.core.designsystem.components.HarooVerticalDivider
-import com.core.designsystem.components.calendar.Calendar
 import com.core.designsystem.theme.HarooTheme
 import com.core.model.feature.PostUiModel
-import com.core.ui.date.DateWithImage
-import com.core.ui.date.RowMonthAndName
 import com.core.ui.post.GridPostItem
 import com.core.ui.post.LinearPostItem
-import com.feature.monthly.ui.rememberToolbarState
+import com.core.ui.toolbar.CollapsingToolbar
+import com.feature.monthly.ui.MonthlyHeader
 import java.time.LocalDate
 import java.time.YearMonth
 
 @Composable
 fun MonthlyScreen(
+    year: Int, month: Int,
     monthlyViewModel: MonthlyViewModel = hiltViewModel()
 ) {
-    val today = YearMonth.now()
-    val dateCount = remember(today) { today.lengthOfMonth() }
+    LaunchedEffect(key1 = Unit) { monthlyViewModel.init(year, month) }
 
-    LaunchedEffect(key1 = Unit) {
-        monthlyViewModel.init(today.year, today.monthValue)
-    }
+    MonthlyScreen(
+        monthlyScreenStateHolder = rememberMonthlyScreenState(
+            year = year,
+            month = month,
+            monthlyViewModel = monthlyViewModel
+        )
+    )
+}
 
-    val posts = monthlyViewModel.posts.collectAsState()
-    val groupedPost = remember(posts.value) { posts.value.associateBy { it.date } }
-
-    // Toolbar 가능 높이
-    val toolbarHeightRange = with(LocalDensity.current) {
-        60.dp.roundToPx()..150.dp.roundToPx()
-    }
-
-    val toolbarState = rememberToolbarState(toolbarHeightRange = toolbarHeightRange)
-    val listState = rememberLazyListState()
-
-    val nestedScrollConnection = remember {
-        object : NestedScrollConnection {
-            // Scroll 이 발생하였을 떄
-            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                toolbarState.scrollTopLimitReached =
-                    listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-                toolbarState.scrollOffset = toolbarState.scrollOffset - available.y
-                return Offset(0f, toolbarState.consumed)
-            }
-        }
-    }
-    val listType = rememberSaveable { mutableStateOf(false) }
-
-    Column(
+@Composable
+fun MonthlyScreen(
+    monthlyScreenStateHolder: MonthlyScreenStateHolder
+) {
+    CollapsingToolbar(
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
             .navigationBarsPadding()
             .imePadding()
-            .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground))
-            .nestedScroll(nestedScrollConnection),
+            .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground)),
+        listState = monthlyScreenStateHolder.lazyListState,
+        toolbarState = monthlyScreenStateHolder.toolbarState
     ) {
         CompositionLocalProvider(
             LocalContentColor provides HarooTheme.colors.text
@@ -89,144 +62,90 @@ fun MonthlyScreen(
             HarooHeader(title = "하루네컷", onBackPressed = {})
             MonthlyHeader(
                 modifier = Modifier.padding(bottom = 26.dp),
-                date = today,
-                posts = groupedPost,
-                progressProvider = { toolbarState.progress }
+                date = monthlyScreenStateHolder.date,
+                posts = monthlyScreenStateHolder.groupedPost,
+                progressProvider = { monthlyScreenStateHolder.toolbarState.progress }
             )
-
-            HarooSurface(
-                modifier = Modifier.fillMaxWidth(),
-                shape = MaterialTheme.shapes.large,
-                alpha = 0.08f
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    HarooRadioButton(
-                        modifier = Modifier.padding(16.dp),
-                        selected = listType.value,
-                        onSelected = { listType.value = listType.value.not() }
-                    )
-                    LazyColumn(
-                        state = listState,
-                        contentPadding = PaddingValues(horizontal = 36.dp)
-                    ) {
-                        items(count = dateCount) {
-                            val day = today.atDay(it + 1)
-                            if (listType.value) {
-                                GridPostItem(
-                                    isFirstItem = it == 0,
-                                    isLastItem = it == dateCount - 1,
-                                    date = today.atDay(it + 1),
-                                    post = groupedPost[day],
-                                    onRemovePost = monthlyViewModel::removePost
-                                )
-                            } else {
-                                LinearPostItem(
-                                    isFirstItem = it == 0,
-                                    isLastItem = it == dateCount - 1,
-                                    date = today.atDay(it + 1),
-                                    post = groupedPost[day],
-                                    onRemovePost = monthlyViewModel::removePost
-                                )
-                            }
-                        }
-                    }
-                }
-            }
+            MonthlyBody(
+                lazyListState = monthlyScreenStateHolder.lazyListState,
+                groupedPosts = monthlyScreenStateHolder.groupedPost,
+                listType = monthlyScreenStateHolder.listType.value,
+                date = monthlyScreenStateHolder.date,
+                dateCount = monthlyScreenStateHolder.dateCount,
+                onChangeListType = monthlyScreenStateHolder::toggleListType,
+                onRemovePost = monthlyScreenStateHolder::removePost
+            )
         }
     }
 }
 
 @Composable
-fun MonthlyHeader(
+fun MonthlyBody(
+    lazyListState: LazyListState,
+    groupedPosts: Map<LocalDate, PostUiModel>,
+    listType: Boolean,
     date: YearMonth,
-    modifier: Modifier = Modifier,
-    verticalSpace: Dp = 8.dp,
-    horizontalSpace: Dp = 8.dp,
-    posts: Map<LocalDate, PostUiModel>,
-    progressProvider: () -> Float
+    dateCount: Int,
+    onChangeListType: () -> Unit,
+    onRemovePost: (PostUiModel) -> Unit
 ) {
-    Layout(
-        modifier = modifier,
-        content = {
-            RowMonthAndName(
-                modifier = Modifier
-                    .layoutId("Date")
-                    .padding(16.dp),
-                date = date
+    HarooSurface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        alpha = 0.08f
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            HarooRadioButton(
+                modifier = Modifier.padding(16.dp),
+                selected = listType,
+                onSelected = onChangeListType
             )
-            Calendar(
-                modifier = Modifier
-                    .layoutId("Calendar")
-                    .graphicsLayer {
-                        val progress = progressProvider()
-                        alpha = progress
-                        scaleY = progress
-                        translationY = (progressProvider() - 1) * (size.height / 2)
-                    },
-                space = verticalSpace,
-                currentMonth = date,
-                dayContent = {
-                    DateWithImage(
-                        modifier = Modifier.padding(horizontal = horizontalSpace),
-                        state = it,
-                        image = posts[it.date]?.images?.firstOrNull()
+            LazyColumn(
+                state = lazyListState,
+                contentPadding = PaddingValues(horizontal = 36.dp)
+            ) {
+                items(count = dateCount) {
+                    val day = date.atDay(it + 1)
+                    MonthlyPostItem(
+                        isFirstItem = it == 0,
+                        isLastItem = it == dateCount - 1,
+                        date = day,
+                        post = groupedPosts[day],
+                        listType = listType,
+                        onRemovePost = onRemovePost
                     )
                 }
-            )
-            Row(
-                modifier = Modifier
-                    .layoutId("Info")
-                    .graphicsLayer { alpha = 1 - progressProvider() }
-                    .fillMaxWidth()
-                    .height(50.dp),
-                horizontalArrangement = Arrangement.Center
-            ) {
-                MonthlyCountContainer(name = "전체일수", count = date.lengthOfMonth())
-                HarooVerticalDivider(modifier = Modifier.padding(horizontal = 30.dp))
-                MonthlyCountContainer(name = "기록일수", count = posts.size)
-                HarooVerticalDivider(modifier = Modifier.padding(horizontal = 30.dp))
-                MonthlyCountContainer(name = "이미지", count = posts.values.sumOf { it.images.size })
             }
-        }
-    ) { measureables, constraints ->
-        val progress = progressProvider()
-        val date = measureables.find { it.layoutId == "Date" }!!.measure(constraints)
-        val calendar = measureables.find { it.layoutId == "Calendar" }!!.measure(constraints)
-        val info = measureables.find { it.layoutId == "Info" }!!.measure(constraints)
-
-        val height = lerp(
-            start = (date.height + info.height).toDp(),
-            stop = (date.height + calendar.height).toDp(),
-            fraction = progress
-        )
-        val dateX = lerp(
-            start = ((constraints.maxWidth - date.width) / 2).toDp(),
-            stop = 0f.toDp(),
-            fraction = progress
-        )
-        layout(
-            constraints.maxWidth,
-            height = height.roundToPx()
-        ) {
-            date.placeRelative(x = dateX.roundToPx(), y = 0)
-            calendar.placeRelative(x = 0, y = date.height)
-            info.placeRelative(x = 0, y = date.height)
         }
     }
 }
 
 @Composable
-fun MonthlyCountContainer(
-    name: String, // info name
-    count: Int // info 개수
+fun MonthlyPostItem(
+    isFirstItem: Boolean,
+    isLastItem: Boolean,
+    date: LocalDate,
+    post: PostUiModel?,
+    listType: Boolean,
+    onRemovePost: (PostUiModel) -> Unit
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Text(text = name, style = MaterialTheme.typography.body1)
-        Text(text = count.toString(), style = MaterialTheme.typography.body1)
+    if (listType) {
+        GridPostItem(
+            isFirstItem = isFirstItem,
+            isLastItem = isLastItem,
+            date = date,
+            post = post,
+            onRemovePost = onRemovePost
+        )
+    } else {
+        LinearPostItem(
+            isFirstItem = isFirstItem,
+            isLastItem = isLastItem,
+            date = date,
+            post = post,
+            onRemovePost = onRemovePost
+        )
     }
 }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -2,31 +2,21 @@ package com.feature.monthly
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.LocalContentColor
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.core.designsystem.R
 import com.core.designsystem.components.HarooHeader
-import com.core.designsystem.components.HarooRadioButton
-import com.core.designsystem.components.HarooSurface
 import com.core.designsystem.theme.HarooTheme
 import com.core.designsystem.util.getString
-import com.core.model.feature.PostUiModel
-import com.core.ui.post.GridPostItem
-import com.core.ui.post.LinearPostItem
 import com.core.ui.toolbar.CollapsingToolbar
 import com.feature.monthly.ui.Dimens
+import com.feature.monthly.ui.MonthlyBody
 import com.feature.monthly.ui.MonthlyHeader
-import java.time.LocalDate
-import java.time.YearMonth
-import com.core.designsystem.R
 
 @Composable
 fun MonthlyScreen(
@@ -78,76 +68,5 @@ fun MonthlyScreen(
                 onRemovePost = monthlyScreenStateHolder::removePost
             )
         }
-    }
-}
-
-@Composable
-fun MonthlyBody(
-    lazyListState: LazyListState,
-    groupedPosts: Map<LocalDate, PostUiModel>,
-    listType: Boolean,
-    date: YearMonth,
-    dateCount: Int,
-    onChangeListType: () -> Unit,
-    onRemovePost: (PostUiModel) -> Unit
-) {
-    HarooSurface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        alpha = 0.08f
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            HarooRadioButton(
-                modifier = Modifier.padding(Dimens.paddingRadioBtn),
-                selected = listType,
-                onSelected = onChangeListType
-            )
-            LazyColumn(
-                state = lazyListState,
-                contentPadding = PaddingValues(horizontal = Dimens.postListHorizontalPadding)
-            ) {
-                items(count = dateCount) {
-                    val day = date.atDay(it + 1)
-                    MonthlyPostItem(
-                        isFirstItem = it == 0,
-                        isLastItem = it == dateCount - 1,
-                        date = day,
-                        post = groupedPosts[day],
-                        listType = listType,
-                        onRemovePost = onRemovePost
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun MonthlyPostItem(
-    isFirstItem: Boolean,
-    isLastItem: Boolean,
-    date: LocalDate,
-    post: PostUiModel?,
-    listType: Boolean,
-    onRemovePost: (PostUiModel) -> Unit
-) {
-    if (listType) {
-        GridPostItem(
-            isFirstItem = isFirstItem,
-            isLastItem = isLastItem,
-            date = date,
-            post = post,
-            onRemovePost = onRemovePost
-        )
-    } else {
-        LinearPostItem(
-            isFirstItem = isFirstItem,
-            isLastItem = isLastItem,
-            date = date,
-            post = post,
-            onRemovePost = onRemovePost
-        )
     }
 }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyUiState.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyUiState.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import com.core.model.feature.PostUiModel
 import com.core.ui.toolbar.ToolbarState
 import com.core.ui.toolbar.rememberToolbarState
+import java.time.LocalDate
 import java.time.YearMonth
 
 @Composable
@@ -27,11 +28,14 @@ fun rememberMonthlyScreenState(
         toolbarMinHeight.roundToPx()..toolbarMaxHeight.roundToPx()
     }
     val toolbarState: ToolbarState = rememberToolbarState(toolbarHeightRange)
+    val groupedPost = remember {
+        derivedStateOf { posts.value.associateBy { it.date } }
+    }
 
     return remember(year, month) {
         MonthlyScreenStateHolder(
             date = YearMonth.of(year, month),
-            posts = posts,
+            posts = groupedPost,
             toolbarState = toolbarState,
             lazyListState = lazyListState,
             listType = listType,
@@ -42,7 +46,7 @@ fun rememberMonthlyScreenState(
 
 class MonthlyScreenStateHolder(
     val date: YearMonth,
-    val posts: State<List<PostUiModel>>,
+    val posts: State<Map<LocalDate,PostUiModel>>,
     val toolbarState: ToolbarState,
     val lazyListState: LazyListState,
     val listType: MutableState<Boolean>,
@@ -50,8 +54,6 @@ class MonthlyScreenStateHolder(
 ) {
     val dateCount: Int
         get() = date.lengthOfMonth()
-
-    val groupedPost = posts.value.associateBy { it.date }
 
     fun toggleListType() {
         listType.value = listType.value.not()

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyUiState.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyUiState.kt
@@ -1,0 +1,63 @@
+package com.feature.monthly
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.core.model.feature.PostUiModel
+import com.core.ui.toolbar.ToolbarState
+import com.core.ui.toolbar.rememberToolbarState
+import java.time.YearMonth
+
+@Composable
+fun rememberMonthlyScreenState(
+    year: Int, month: Int,
+    monthlyViewModel: MonthlyViewModel,
+    toolbarMinHeight: Dp = 60.dp,
+    toolbarMaxHeight: Dp = 150.dp,
+    lazyListState: LazyListState = rememberLazyListState()
+): MonthlyScreenStateHolder {
+    val posts = monthlyViewModel.posts.collectAsState()
+    val listType = rememberSaveable { mutableStateOf(false) }
+
+    val toolbarHeightRange = with(LocalDensity.current) {
+        toolbarMinHeight.roundToPx()..toolbarMaxHeight.roundToPx()
+    }
+    val toolbarState: ToolbarState = rememberToolbarState(toolbarHeightRange)
+
+    return remember(year, month) {
+        MonthlyScreenStateHolder(
+            date = YearMonth.of(year, month),
+            posts = posts,
+            toolbarState = toolbarState,
+            lazyListState = lazyListState,
+            listType = listType,
+            onRemovePost = monthlyViewModel::removePost
+        )
+    }
+}
+
+class MonthlyScreenStateHolder(
+    val date: YearMonth,
+    val posts: State<List<PostUiModel>>,
+    val toolbarState: ToolbarState,
+    val lazyListState: LazyListState,
+    val listType: MutableState<Boolean>,
+    val onRemovePost: (PostUiModel) -> Unit
+) {
+    val dateCount: Int
+        get() = date.lengthOfMonth()
+
+    val groupedPost = posts.value.associateBy { it.date }
+
+    fun toggleListType() {
+        listType.value = listType.value.not()
+    }
+
+    fun removePost(postUiModel: PostUiModel) {
+        onRemovePost(postUiModel)
+    }
+}

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
@@ -3,6 +3,7 @@ package com.feature.monthly
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.core.domain.post.GetPostByMonthUseCase
+import com.core.domain.post.RemovePostUseCase
 import com.core.model.feature.PostUiModel
 import com.core.model.feature.toPostUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,7 +15,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MonthlyViewModel @Inject constructor(
-    private val getPostByMonthUseCase: GetPostByMonthUseCase
+    private val getPostByMonthUseCase: GetPostByMonthUseCase,
+    private val removePostUseCase: RemovePostUseCase
 ) : ViewModel() {
 
     private val _posts = MutableStateFlow<List<PostUiModel>>(emptyList())
@@ -24,6 +26,15 @@ class MonthlyViewModel @Inject constructor(
         viewModelScope.launch {
             _posts.value = getPostByMonthUseCase(year, month).map { it.toPostUiModel() }
             println(_posts.value)
+        }
+    }
+
+    fun removePost(postUiModel: PostUiModel) {
+        viewModelScope.launch {
+            postUiModel.id?.let { postId ->
+                removePostUseCase(postId)
+                _posts.value = _posts.value.filterNot { it == postUiModel }
+            }
         }
     }
 }

--- a/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyBody.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyBody.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.Modifier
 import com.core.designsystem.components.HarooRadioButton
 import com.core.designsystem.components.HarooSurface
 import com.core.model.feature.PostUiModel
-import com.core.ui.post.GridPostItem
-import com.core.ui.post.LinearPostItem
+import com.core.ui.post.PostItemByType
+import com.core.ui.post.PostItemType
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -52,7 +52,7 @@ fun MonthlyBody(
                         isLastItem = it == dateCount - 1,
                         date = day,
                         post = groupedPosts[day],
-                        listType = listType,
+                        postItemType = if (listType) PostItemType.GRID else PostItemType.LINEAR,
                         onRemovePost = onRemovePost
                     )
                 }
@@ -67,24 +67,15 @@ fun MonthlyPostItem(
     isLastItem: Boolean,
     date: LocalDate,
     post: PostUiModel?,
-    listType: Boolean,
+    postItemType: PostItemType,
     onRemovePost: (PostUiModel) -> Unit
 ) {
-    if (listType) {
-        GridPostItem(
-            isFirstItem = isFirstItem,
-            isLastItem = isLastItem,
-            date = date,
-            post = post,
-            onRemovePost = onRemovePost
-        )
-    } else {
-        LinearPostItem(
-            isFirstItem = isFirstItem,
-            isLastItem = isLastItem,
-            date = date,
-            post = post,
-            onRemovePost = onRemovePost
-        )
-    }
+    PostItemByType(
+        date = date,
+        isFirstItem = isFirstItem,
+        isLastItem = isLastItem,
+        post = post,
+        postItemType = postItemType,
+        onRemovePost = onRemovePost
+    )
 }

--- a/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyBody.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyBody.kt
@@ -1,0 +1,90 @@
+package com.feature.monthly.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.core.designsystem.components.HarooRadioButton
+import com.core.designsystem.components.HarooSurface
+import com.core.model.feature.PostUiModel
+import com.core.ui.post.GridPostItem
+import com.core.ui.post.LinearPostItem
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Composable
+fun MonthlyBody(
+    lazyListState: LazyListState,
+    groupedPosts: Map<LocalDate, PostUiModel>,
+    listType: Boolean,
+    date: YearMonth,
+    dateCount: Int,
+    onChangeListType: () -> Unit,
+    onRemovePost: (PostUiModel) -> Unit
+) {
+    HarooSurface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        alpha = 0.08f
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            HarooRadioButton(
+                modifier = Modifier.padding(Dimens.paddingRadioBtn),
+                selected = listType,
+                onSelected = onChangeListType
+            )
+            LazyColumn(
+                state = lazyListState,
+                contentPadding = PaddingValues(horizontal = Dimens.postListHorizontalPadding)
+            ) {
+                items(count = dateCount) {
+                    val day = date.atDay(it + 1)
+                    MonthlyPostItem(
+                        isFirstItem = it == 0,
+                        isLastItem = it == dateCount - 1,
+                        date = day,
+                        post = groupedPosts[day],
+                        listType = listType,
+                        onRemovePost = onRemovePost
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun MonthlyPostItem(
+    isFirstItem: Boolean,
+    isLastItem: Boolean,
+    date: LocalDate,
+    post: PostUiModel?,
+    listType: Boolean,
+    onRemovePost: (PostUiModel) -> Unit
+) {
+    if (listType) {
+        GridPostItem(
+            isFirstItem = isFirstItem,
+            isLastItem = isLastItem,
+            date = date,
+            post = post,
+            onRemovePost = onRemovePost
+        )
+    } else {
+        LinearPostItem(
+            isFirstItem = isFirstItem,
+            isLastItem = isLastItem,
+            date = date,
+            post = post,
+            onRemovePost = onRemovePost
+        )
+    }
+}

--- a/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyHeader.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyHeader.kt
@@ -14,11 +14,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import com.core.designsystem.components.HarooVerticalDivider
 import com.core.designsystem.components.calendar.Calendar
+import com.core.designsystem.util.getString
 import com.core.model.feature.PostUiModel
 import com.core.ui.date.DateWithImage
 import com.core.ui.date.RowMonthAndName
 import java.time.LocalDate
 import java.time.YearMonth
+import com.feature.monthly.R
 
 @Composable
 fun MonthlyHeader(
@@ -66,12 +68,13 @@ fun MonthlyHeader(
 fun MonthlyHeaderContent(
     date: YearMonth,
     posts: Map<LocalDate, PostUiModel>,
+    monthAndNamePadding: Dp = Dimens.monthAndNameDefaultPadding,
     progressProvider: () -> Float
 ) {
     RowMonthAndName(
         modifier = Modifier
             .layoutId("Date")
-            .padding(16.dp),
+            .padding(monthAndNamePadding),
         date = date
     )
     MonthlyCalendar(
@@ -93,8 +96,8 @@ fun MonthlyCalendar(
     modifier: Modifier = Modifier,
     posts: Map<LocalDate, PostUiModel>,
     date: YearMonth,
-    verticalSpace: Dp = 8.dp,
-    horizontalSpace: Dp = 8.dp,
+    verticalSpace: Dp = Dimens.monthlyCalendarVerticalSpace,
+    horizontalSpace: Dp = Dimens.monthlyCalendarHorizontalSpace,
     progressProvider: () -> Float
 ) {
     Calendar(
@@ -122,7 +125,7 @@ fun MonthlyInfosContainer(
     modifier: Modifier = Modifier,
     posts: Map<LocalDate, PostUiModel>,
     date: YearMonth,
-    space: Dp = 30.dp,
+    space: Dp = Dimens.monthlyInfoHorizontalSpace,
     progressProvider: () -> Float
 ) {
     Row(
@@ -132,22 +135,31 @@ fun MonthlyInfosContainer(
             .graphicsLayer { alpha = 1 - progressProvider() },
         horizontalArrangement = Arrangement.Center
     ) {
-        MonthlyCountContainer(name = "전체일수", count = date.lengthOfMonth())
+        MonthlyCountContainer(
+            name = getString(id = R.string.total_date),
+            count = date.lengthOfMonth()
+        )
         HarooVerticalDivider(modifier = Modifier.padding(horizontal = space))
-        MonthlyCountContainer(name = "기록일수", count = posts.size)
+        MonthlyCountContainer(
+            name = getString(id = R.string.post_count),
+            count = posts.size
+        )
         HarooVerticalDivider(modifier = Modifier.padding(horizontal = space))
-        MonthlyCountContainer(name = "이미지", count = posts.values.sumOf { it.images.size })
+        MonthlyCountContainer(
+            name = getString(id = R.string.image_count),
+            count = posts.values.sumOf { it.images.size })
     }
 }
 
 @Composable
 fun MonthlyCountContainer(
     name: String, // info name
-    count: Int // info 개수
+    count: Int, // info 개수
+    verticalSpace: Dp = Dimens.monthlyInfoVerticalSpace
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(verticalSpace)
     ) {
         Text(text = name, style = MaterialTheme.typography.body1)
         Text(text = count.toString(), style = MaterialTheme.typography.body1)

--- a/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyHeader.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyHeader.kt
@@ -1,0 +1,155 @@
+package com.feature.monthly.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import com.core.designsystem.components.HarooVerticalDivider
+import com.core.designsystem.components.calendar.Calendar
+import com.core.model.feature.PostUiModel
+import com.core.ui.date.DateWithImage
+import com.core.ui.date.RowMonthAndName
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Composable
+fun MonthlyHeader(
+    modifier: Modifier = Modifier,
+    posts: Map<LocalDate, PostUiModel>,
+    date: YearMonth,
+    progressProvider: () -> Float
+) {
+    Layout(
+        modifier = modifier,
+        content = {
+            MonthlyHeaderContent(
+                date = date,
+                posts = posts,
+                progressProvider = progressProvider
+            )
+        }
+    ) { measureables, constraints ->
+        val progress = progressProvider()
+        val day = measureables.find { it.layoutId == "Date" }!!.measure(constraints)
+        val calendar = measureables.find { it.layoutId == "Calendar" }!!.measure(constraints)
+        val info = measureables.find { it.layoutId == "Info" }!!.measure(constraints)
+        val height = lerp(
+            start = (day.height + info.height).toDp(),
+            stop = (day.height + calendar.height).toDp(),
+            fraction = progress
+        )
+        val dayX = lerp(
+            start = ((constraints.maxWidth - day.width) / 2).toDp(),
+            stop = 0f.dp,
+            fraction = progress
+        )
+        layout(
+            width = constraints.maxWidth,
+            height = height.roundToPx()
+        ) {
+            day.placeRelative(x = dayX.roundToPx(), y = 0)
+            calendar.placeRelative(x = 0, y = day.height)
+            info.placeRelative(x = 0, y = day.height)
+        }
+    }
+}
+
+@Composable
+fun MonthlyHeaderContent(
+    date: YearMonth,
+    posts: Map<LocalDate, PostUiModel>,
+    progressProvider: () -> Float
+) {
+    RowMonthAndName(
+        modifier = Modifier
+            .layoutId("Date")
+            .padding(16.dp),
+        date = date
+    )
+    MonthlyCalendar(
+        modifier = Modifier.layoutId("Calendar"),
+        posts = posts,
+        date = date,
+        progressProvider = progressProvider
+    )
+    MonthlyInfosContainer(
+        modifier = Modifier.layoutId("Info"),
+        posts = posts,
+        date = date,
+        progressProvider = progressProvider
+    )
+}
+
+@Composable
+fun MonthlyCalendar(
+    modifier: Modifier = Modifier,
+    posts: Map<LocalDate, PostUiModel>,
+    date: YearMonth,
+    verticalSpace: Dp = 8.dp,
+    horizontalSpace: Dp = 8.dp,
+    progressProvider: () -> Float
+) {
+    Calendar(
+        currentMonth = date,
+        space = verticalSpace,
+        modifier = modifier
+            .graphicsLayer {
+                val progress = progressProvider()
+                alpha = progress
+                scaleY = progress
+                translationY = (progress - 1) * (size.height / 2)
+            },
+        dayContent = {
+            DateWithImage(
+                modifier = Modifier.padding(horizontal = horizontalSpace),
+                state = it,
+                image = posts[it.date]?.images?.firstOrNull()
+            )
+        }
+    )
+}
+
+@Composable
+fun MonthlyInfosContainer(
+    modifier: Modifier = Modifier,
+    posts: Map<LocalDate, PostUiModel>,
+    date: YearMonth,
+    space: Dp = 30.dp,
+    progressProvider: () -> Float
+) {
+    Row(
+        modifier = modifier
+            .height(IntrinsicSize.Min)
+            .fillMaxWidth()
+            .graphicsLayer { alpha = 1 - progressProvider() },
+        horizontalArrangement = Arrangement.Center
+    ) {
+        MonthlyCountContainer(name = "전체일수", count = date.lengthOfMonth())
+        HarooVerticalDivider(modifier = Modifier.padding(horizontal = space))
+        MonthlyCountContainer(name = "기록일수", count = posts.size)
+        HarooVerticalDivider(modifier = Modifier.padding(horizontal = space))
+        MonthlyCountContainer(name = "이미지", count = posts.values.sumOf { it.images.size })
+    }
+}
+
+@Composable
+fun MonthlyCountContainer(
+    name: String, // info name
+    count: Int // info 개수
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(text = name, style = MaterialTheme.typography.body1)
+        Text(text = count.toString(), style = MaterialTheme.typography.body1)
+    }
+}

--- a/feature/monthly/src/main/java/com/feature/monthly/ui/dimens.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/ui/dimens.kt
@@ -9,4 +9,9 @@ internal object Dimens {
 
     val monthlyCalendarVerticalSpace = 8.dp
     val monthlyCalendarHorizontalSpace = 8.dp
+
+    val spaceBetweenHeaderAndBody = 26.dp
+    val paddingRadioBtn = 16.dp
+
+    val postListHorizontalPadding = 36.dp
 }

--- a/feature/monthly/src/main/java/com/feature/monthly/ui/dimens.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/ui/dimens.kt
@@ -1,0 +1,12 @@
+package com.feature.monthly.ui
+
+import androidx.compose.ui.unit.dp
+
+internal object Dimens {
+    val monthAndNameDefaultPadding = 16.dp
+    val monthlyInfoVerticalSpace = 16.dp
+    val monthlyInfoHorizontalSpace =30.dp
+
+    val monthlyCalendarVerticalSpace = 8.dp
+    val monthlyCalendarHorizontalSpace = 8.dp
+}

--- a/feature/monthly/src/main/res/values/strings.xml
+++ b/feature/monthly/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Monthly header Info -->
+    <string name="total_date">전체 일수</string>
+    <string name="post_count">기록 일수</string>
+    <string name="image_count">이미지</string>
+</resources>


### PR DESCRIPTION
#### 📌 내용
Monthly Screen에 포함된 비지니스 로직을 구현하고 테스트하기

#### 🛠 Done
- [x] Post 제거 기능 추가
- [x] Post 제거 시, UI에 반영하기
- [x] UiState로 통합하기

#### 🔥 추가 작업
Monthly Screen에서 LinearPostItem과 GridPostItem의 코드에서 비슷한 부분이 많이 이를 하나로 통일하도록 수정

공통적인 부분은 부모 class인 PostItem으로
별도의 부분은 LinearPostItem과 GridPostItem으로 만들고 PostItem을 상속받도록 하였습니다.
수정이 필요한 부분은 override 하여 사용할 수 있도록 하였습니다.
```
관련 내용은 블로그에 정리해 공유드리도록 하겠습니다. 🤗
```

#### 🏠 관련 Issue
Closed #36 
