### PR TITLE
[FEAT] #38 MainActivition Navigation & AppState

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ android {
 dependencies {
     implementation(project(":feature:post"))
     implementation(project(":feature:home"))
+    implementation(project(":feature:monthly"))
     implementation(project(":core:designsystem"))
 
     testImplementation(libs.junit4)

--- a/app/src/main/java/com/haman/allformemory/MainActivity.kt
+++ b/app/src/main/java/com/haman/allformemory/MainActivity.kt
@@ -9,7 +9,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.LaunchedEffect
 import androidx.core.view.WindowCompat
 import com.core.designsystem.theme.AllForMemoryTheme
-import com.feature.home.HomeScreen
+import com.haman.allformemory.ui.HarooApp
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -38,7 +38,7 @@ class MainActivity : ComponentActivity() {
                         requestPermissionLauncher.launch(arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE))
                     }
                 }
-                HomeScreen()
+                HarooApp()
             }
         }
     }

--- a/app/src/main/java/com/haman/allformemory/navigation/HarooNavHost.kt
+++ b/app/src/main/java/com/haman/allformemory/navigation/HarooNavHost.kt
@@ -1,0 +1,37 @@
+package com.haman.allformemory.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import com.feature.home.HOME_SCREEN_ROUTE
+import com.feature.home.homeScreen
+import com.feature.monthly.monthlyScreen
+import com.feature.monthly.navigateToMonthly
+import com.feature.post.navigateToPost
+import com.feature.post.postScreen
+
+@Composable
+fun HarooNavHost(
+    modifier: Modifier = Modifier,
+    navController: NavHostController,
+    startDestination: String = HOME_SCREEN_ROUTE
+) {
+    NavHost(
+        modifier = modifier,
+        navController = navController,
+        startDestination = startDestination
+    ) {
+        homeScreen(
+            onDailyClick = { navController.navigateToPost(it) },
+            onMonthlyClick = { navController.navigateToMonthly(it) }
+        )
+        monthlyScreen(
+            onBackPressed = navController::popBackStack,
+            onDailyClick = { navController.navigateToPost(it) }
+        )
+        postScreen(
+            onBackPressed = navController::popBackStack
+        )
+    }
+}

--- a/app/src/main/java/com/haman/allformemory/ui/HarooApp.kt
+++ b/app/src/main/java/com/haman/allformemory/ui/HarooApp.kt
@@ -1,16 +1,35 @@
 package com.haman.allformemory.ui
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import com.core.designsystem.theme.HarooTheme
 import com.haman.allformemory.navigation.HarooNavHost
 
 @Composable
 fun HarooApp(
+    backgroundColor: List<Color> = HarooTheme.colors.interactiveBackground,
     harooAppState: HarooAppState = rememberHarooAppState()
 ) {
-    Scaffold() {
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .imePadding()
+            .drawBehind {
+                drawRect(brush = Brush.linearGradient(backgroundColor))
+            },
+        backgroundColor = Color.Transparent
+    ) {
         HarooNavHost(
             modifier = Modifier.padding(it),
             navController = harooAppState.navController

--- a/app/src/main/java/com/haman/allformemory/ui/HarooApp.kt
+++ b/app/src/main/java/com/haman/allformemory/ui/HarooApp.kt
@@ -1,0 +1,19 @@
+package com.haman.allformemory.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.haman.allformemory.navigation.HarooNavHost
+
+@Composable
+fun HarooApp(
+    harooAppState: HarooAppState = rememberHarooAppState()
+) {
+    Scaffold() {
+        HarooNavHost(
+            modifier = Modifier.padding(it),
+            navController = harooAppState.navController
+        )
+    }
+}

--- a/app/src/main/java/com/haman/allformemory/ui/HarooAppState.kt
+++ b/app/src/main/java/com/haman/allformemory/ui/HarooAppState.kt
@@ -1,0 +1,27 @@
+package com.haman.allformemory.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+
+@Composable
+fun rememberHarooAppState(
+    navController: NavHostController = rememberNavController()
+): HarooAppState {
+    return remember(navController) {
+        HarooAppState(navController)
+    }
+}
+
+@Stable
+class HarooAppState(
+    val navController: NavHostController
+) {
+    val currentDestination: NavDestination?
+        @Composable get() = navController
+            .currentBackStackEntryAsState().value?.destination
+}

--- a/core/data/src/main/java/com/core/data/post/PostRepository.kt
+++ b/core/data/src/main/java/com/core/data/post/PostRepository.kt
@@ -25,7 +25,7 @@ interface PostRepository {
     suspend fun getPosts(year: Int, month: Int): List<PostSource>
 
     // 특정 년도/월 post paging 요청
-    fun getPostPaging(year: Int, month: Int): Flow<PagingData<PostSources>>
+    fun getPostPaging(): Flow<PagingData<PostSources>>
 
     // 특정 날짜의 게시글 제거
     suspend fun removePost(postId: Long)

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
@@ -5,7 +5,14 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.core.data.post.PostRepository
 import com.core.database.dao.PostDao
-import com.core.model.data.*
+import com.core.model.data.ImageSource
+import com.core.model.data.PostSource
+import com.core.model.data.PostSources
+import com.core.model.data.TagSource
+import com.core.model.data.toImageEntity
+import com.core.model.data.toPostEntity
+import com.core.model.data.toSource
+import com.core.model.data.toTagEntity
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -95,10 +102,7 @@ class PostLocalRepositoryImpl @Inject constructor(
             }.awaitAll().filterNotNull()
         }
 
-    override fun getPostPaging(
-        year: Int,
-        month: Int
-    ): Flow<PagingData<PostSources>> {
+    override fun getPostPaging(): Flow<PagingData<PostSources>> {
         return Pager(
             config = PagingConfig(
                 pageSize = PostLocalPagingSource.PAGING_SIZE

--- a/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonthUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonthUseCase.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class GetPostPageByMonthUseCase @Inject constructor(
     private val postRepository: PostRepository
 ) {
-    operator fun invoke(year: Int, month: Int): Flow<PagingData<Posts>> {
-        return postRepository.getPostPaging(year, month).map { it.map { post -> post.toPosts() } }
+    operator fun invoke(): Flow<PagingData<Posts>> {
+        return postRepository.getPostPaging().map { it.map { post -> post.toPosts() } }
     }
 }

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -94,7 +94,8 @@ fun BasePostItem(
     date: LocalDate,
     contentColor: Color,
     imageContainer: @Composable (Modifier, List<ImageUiModel>) -> Unit,
-    onRemovePost: (PostUiModel) -> Unit
+    onRemovePost: (PostUiModel) -> Unit,
+    onClickPost: (LocalDate) -> Unit
 ) {
     HarooVerticalDivider(modifier = Modifier.layoutId("Line"), dash = 0f)
     Canvas(modifier = Modifier.layoutId("Dot")) { drawCircle(contentColor) }
@@ -105,7 +106,11 @@ fun BasePostItem(
         dateTextStyle = MaterialTheme.typography.body1
     )
     if (post != null) {
-        imageContainer(Modifier.layoutId("Images"), post.images)
+        imageContainer(
+            Modifier
+                .layoutId("Images")
+                .noRippleClickable { onClickPost(date) }, post.images
+        )
         IconButton(modifier = Modifier
             .layoutId("DelBtn")
             .size(20.dp), onClick = { onRemovePost(post) }
@@ -175,7 +180,8 @@ fun PostItemByType(
     contentColor: Color = LocalContentColor.current,
     post: PostUiModel?, // 해당 일의 Post 정보
     postItemType: PostItemType,
-    onRemovePost: (PostUiModel) -> Unit
+    onRemovePost: (PostUiModel) -> Unit,
+    onClickPost: (LocalDate) -> Unit
 ) {
     PostItem(
         modifier = modifier,
@@ -195,7 +201,8 @@ fun PostItemByType(
                         images = images
                     )
                 },
-                onRemovePost = onRemovePost
+                onRemovePost = onRemovePost,
+                onClickPost = onClickPost
             )
         }
     )

--- a/core/ui/src/main/java/com/core/ui/post/Post.kt
+++ b/core/ui/src/main/java/com/core/ui/post/Post.kt
@@ -140,7 +140,7 @@ fun BasePostItem(
     } else {
         HarooButton(
             modifier = Modifier.layoutId("AddBtn"),
-            onClick = { }
+            onClick = { onClickPost(date) }
         ) { Text(text = "추가") }
     }
 }

--- a/feature/home/src/main/java/com/feature/home/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeNavigation.kt
@@ -1,0 +1,20 @@
+package com.feature.home
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import java.time.LocalDate
+import java.time.YearMonth
+
+private const val HOME_SCREEN_ROUTE = "home"
+
+fun NavGraphBuilder.homeScreen(
+    onDailyClick: (LocalDate) -> Unit,
+    onMonthlyClick: (YearMonth) -> Unit
+) {
+    composable(route = HOME_SCREEN_ROUTE) {
+        HomeRoute(
+            onDailyClick = onDailyClick,
+            onMonthlyClick = onMonthlyClick
+        )
+    }
+}

--- a/feature/home/src/main/java/com/feature/home/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeNavigation.kt
@@ -5,7 +5,7 @@ import androidx.navigation.compose.composable
 import java.time.LocalDate
 import java.time.YearMonth
 
-private const val HOME_SCREEN_ROUTE = "home"
+const val HOME_SCREEN_ROUTE = "home"
 
 fun NavGraphBuilder.homeScreen(
     onDailyClick: (LocalDate) -> Unit,

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -2,7 +2,6 @@ package com.feature.home
 
 import android.content.res.Configuration
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -16,7 +15,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -29,7 +27,6 @@ import com.core.designsystem.components.HarooDashLine
 import com.core.designsystem.components.HarooDivider
 import com.core.designsystem.components.calendar.Calendar
 import com.core.designsystem.modifiers.pagerHingeTransition
-import com.core.designsystem.theme.HarooTheme
 import com.core.designsystem.util.getString
 import com.core.model.feature.PostUiModel
 import com.core.model.feature.PostsUiModel
@@ -54,10 +51,11 @@ fun HomeRoute(
         initialFirstVisibleItemScrollOffset = -configuration.screenHeightDp / 3
     )
 
-    LaunchedEffect(key1 = Unit) {
+    LaunchedEffect(key1 = Unit){
         homeViewModel.homeUiEvent.collect {
             when (it) {
                 HomeUiEvent.Initialized -> {}
+                HomeUiEvent.Loading -> {}
                 is HomeUiEvent.Success.RemovePost -> postPagingItems.refresh()
             }
         }

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -81,11 +81,6 @@ fun HomeScreen(
     onRemovePost: (PostUiModel) -> Unit
 ) {
     LazyColumn(
-        modifier = Modifier
-            .statusBarsPadding()
-            .navigationBarsPadding()
-            .imePadding()
-            .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground)),
         horizontalAlignment = Alignment.CenterHorizontally,
         state = scrollState
     ) {

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -42,7 +42,9 @@ import java.time.YearMonth
 private val componentVerticalSpacer = 16.dp
 
 @Composable
-fun HomeScreen(
+fun HomeRoute(
+    onDailyClick: (LocalDate) -> Unit,
+    onMonthlyClick: (YearMonth) -> Unit,
     homeViewModel: HomeViewModel = hiltViewModel(),
     configuration: Configuration = LocalConfiguration.current
 ) {
@@ -64,7 +66,8 @@ fun HomeScreen(
     HomeScreen(
         postPagingItems = postPagingItems,
         scrollState = scrollState,
-        toPostScreen = {},
+        toPostScreen = onDailyClick,
+        toMonthlyScreen = onMonthlyClick,
         onRemovePost = homeViewModel::removePost
     )
 }
@@ -74,6 +77,7 @@ fun HomeScreen(
     postPagingItems: LazyPagingItems<PostsUiModel>,
     scrollState: LazyListState,
     toPostScreen: (LocalDate) -> Unit,
+    toMonthlyScreen: (YearMonth) -> Unit,
     onRemovePost: (PostUiModel) -> Unit
 ) {
     LazyColumn(
@@ -93,7 +97,8 @@ fun HomeScreen(
                 MonthlyContainer(
                     date = postsUiModel.date,
                     posts = postsUiModel.posts,
-                    onClickPost = {},
+                    onClickPost = toPostScreen,
+                    onClickMonth = toMonthlyScreen,
                     onRemovePost = onRemovePost
                 )
             }
@@ -110,6 +115,7 @@ fun MonthlyContainer(
     modifier: Modifier = Modifier,
     posts: List<PostUiModel>,
     onClickPost: (LocalDate) -> Unit,
+    onClickMonth: (YearMonth) -> Unit,
     onRemovePost: (PostUiModel) -> Unit
 ) {
     val groupedPosts = remember(posts) { posts.associateBy { it.date } }
@@ -130,7 +136,7 @@ fun MonthlyContainer(
                 onRemovePost = onRemovePost
             )
         }
-        MonthlyDivider(date = date, onClickMonthBtn = {})
+        MonthlyDivider(date = date, onClickMonthBtn = onClickMonth)
     }
 }
 

--- a/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
@@ -34,6 +34,7 @@ class HomeViewModel @Inject constructor(
 
     fun removePost(postUiModel: PostUiModel) {
         viewModelScope.launch {
+            _homeUiEvent.value = HomeUiEvent.Loading
             postUiModel.id?.let {
                 removePostUseCase(it)
                 _homeUiEvent.value = HomeUiEvent.Success.RemovePost
@@ -44,8 +45,9 @@ class HomeViewModel @Inject constructor(
 
 sealed interface HomeUiEvent {
     object Initialized : HomeUiEvent
+    object Loading : HomeUiEvent
     sealed interface Success : HomeUiEvent {
         // Post 제거 성공 event
-        object RemovePost: Success
+        object RemovePost : Success
     }
 }

--- a/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import java.time.YearMonth
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,14 +21,10 @@ class HomeViewModel @Inject constructor(
     getPostPageByMonthUseCase: GetPostPageByMonthUseCase,
     private val removePostUseCase: RemovePostUseCase
 ) : ViewModel() {
-
     private val _homeUiEvent = MutableStateFlow<HomeUiEvent>(HomeUiEvent.Initialized)
     val homeUiEvent: StateFlow<HomeUiEvent> = _homeUiEvent.asStateFlow()
 
-    private val initDay = YearMonth.now()
-    val posts = getPostPageByMonthUseCase(
-        initDay.year, initDay.monthValue
-    ).map { it.map { post -> post.toPostsUiModel() } }
+    val posts = getPostPageByMonthUseCase().map { it.map { post -> post.toPostsUiModel() } }
         .cachedIn(viewModelScope)
 
     fun removePost(postUiModel: PostUiModel) {

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyNavigation.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyNavigation.kt
@@ -1,0 +1,49 @@
+package com.feature.monthly
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import java.time.LocalDate
+import java.time.YearMonth
+
+private const val YEAR_ARG = "year"
+private const val MONTH_ARG = "month"
+private const val MONTHLY_SCREEN_ROUTE = "monthly"
+
+internal class YearMonthArg(savedStateHandle: SavedStateHandle) {
+    var currentYearMonth: YearMonth
+
+    init {
+        val year: Int? = savedStateHandle[YEAR_ARG]
+        val month: Int? = savedStateHandle[MONTH_ARG]
+        currentYearMonth = if (year == null || month == null)
+            YearMonth.of(year!!, month!!) else YearMonth.now()
+    }
+}
+
+fun NavController.navigateToMonthly(yearMonth: YearMonth) {
+    val year = yearMonth.year
+    val month = yearMonth.monthValue
+    this.navigate("$MONTHLY_SCREEN_ROUTE/$year/$month")
+}
+
+fun NavGraphBuilder.monthlyScreen(
+    onBackPressed: () -> Unit,
+    onDailyClick: (LocalDate) -> Unit
+) {
+    composable(
+        route = "$MONTHLY_SCREEN_ROUTE/$YEAR_ARG/$MONTH_ARG",
+        arguments = listOf(
+            navArgument(YEAR_ARG) { type = NavType.IntType },
+            navArgument(MONTH_ARG) { type = NavType.IntType }
+        )
+    ) {
+        MonthlyRoute(
+            onBackPressed = onBackPressed,
+            onDailyClick = onDailyClick
+        )
+    }
+}

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyNavigation.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyNavigation.kt
@@ -20,7 +20,7 @@ internal class YearMonthArg(savedStateHandle: SavedStateHandle) {
         val year: Int? = savedStateHandle[YEAR_ARG]
         val month: Int? = savedStateHandle[MONTH_ARG]
         currentYearMonth = if (year == null || month == null)
-            YearMonth.of(year!!, month!!) else YearMonth.now()
+            YearMonth.now() else YearMonth.of(year, month)
     }
 }
 

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyNavigation.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyNavigation.kt
@@ -35,7 +35,7 @@ fun NavGraphBuilder.monthlyScreen(
     onDailyClick: (LocalDate) -> Unit
 ) {
     composable(
-        route = "$MONTHLY_SCREEN_ROUTE/$YEAR_ARG/$MONTH_ARG",
+        route = "$MONTHLY_SCREEN_ROUTE/{${YEAR_ARG}}/{${MONTH_ARG}}",
         arguments = listOf(
             navArgument(YEAR_ARG) { type = NavType.IntType },
             navArgument(MONTH_ARG) { type = NavType.IntType }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -28,10 +28,7 @@ fun MonthlyRoute(
     MonthlyScreen(
         onBackPressed = onBackPressed,
         onDailyClick = onDailyClick,
-        monthlyScreenStateHolder = rememberMonthlyScreenState(
-            monthlyViewModel.date.currentYearMonth,
-            monthlyViewModel = monthlyViewModel
-        )
+        monthlyScreenStateHolder = rememberMonthlyScreenState(monthlyViewModel = monthlyViewModel)
     )
 }
 

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -1,13 +1,10 @@
 package com.feature.monthly
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.core.designsystem.R
 import com.core.designsystem.components.HarooHeader
@@ -39,12 +36,6 @@ fun MonthlyScreen(
     monthlyScreenStateHolder: MonthlyScreenStateHolder
 ) {
     CollapsingToolbar(
-        modifier = Modifier
-            .fillMaxSize()
-            .statusBarsPadding()
-            .navigationBarsPadding()
-            .imePadding()
-            .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground)),
         listState = monthlyScreenStateHolder.lazyListState,
         toolbarState = monthlyScreenStateHolder.toolbarState
     ) {

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -17,18 +17,19 @@ import com.core.ui.toolbar.CollapsingToolbar
 import com.feature.monthly.ui.Dimens
 import com.feature.monthly.ui.MonthlyBody
 import com.feature.monthly.ui.MonthlyHeader
+import java.time.LocalDate
 
 @Composable
-fun MonthlyScreen(
-    year: Int, month: Int,
+fun MonthlyRoute(
+    onBackPressed: () -> Unit,
+    onDailyClick: (LocalDate) -> Unit,
     monthlyViewModel: MonthlyViewModel = hiltViewModel()
 ) {
-    LaunchedEffect(key1 = Unit) { monthlyViewModel.init(year, month) }
-
     MonthlyScreen(
+        onBackPressed = onBackPressed,
+        onDailyClick = onDailyClick,
         monthlyScreenStateHolder = rememberMonthlyScreenState(
-            year = year,
-            month = month,
+            monthlyViewModel.date.currentYearMonth,
             monthlyViewModel = monthlyViewModel
         )
     )
@@ -36,6 +37,8 @@ fun MonthlyScreen(
 
 @Composable
 fun MonthlyScreen(
+    onBackPressed: () -> Unit,
+    onDailyClick: (LocalDate) -> Unit,
     monthlyScreenStateHolder: MonthlyScreenStateHolder
 ) {
     CollapsingToolbar(
@@ -51,11 +54,12 @@ fun MonthlyScreen(
         CompositionLocalProvider(
             LocalContentColor provides HarooTheme.colors.text
         ) {
-            HarooHeader(title = getString(id = R.string.app_name), onBackPressed = {})
+            HarooHeader(title = getString(id = R.string.app_name), onBackPressed = onBackPressed)
             MonthlyHeader(
                 modifier = Modifier.padding(bottom = Dimens.spaceBetweenHeaderAndBody),
                 date = monthlyScreenStateHolder.date,
                 posts = monthlyScreenStateHolder.posts.value,
+                toPostScreen = onDailyClick,
                 progressProvider = { monthlyScreenStateHolder.toolbarState.progress }
             )
             MonthlyBody(
@@ -65,7 +69,8 @@ fun MonthlyScreen(
                 date = monthlyScreenStateHolder.date,
                 dateCount = monthlyScreenStateHolder.dateCount,
                 onChangeListType = monthlyScreenStateHolder::toggleListType,
-                onRemovePost = monthlyScreenStateHolder::removePost
+                onRemovePost = monthlyScreenStateHolder::removePost,
+                onClickPost = onDailyClick
             )
         }
     }

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.core.designsystem.R
@@ -22,6 +23,10 @@ fun MonthlyRoute(
     onDailyClick: (LocalDate) -> Unit,
     monthlyViewModel: MonthlyViewModel = hiltViewModel()
 ) {
+    LaunchedEffect(key1 = Unit) {
+        monthlyViewModel.getPost()
+    }
+
     MonthlyScreen(
         onBackPressed = onBackPressed,
         onDailyClick = onDailyClick,

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyUiState.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyUiState.kt
@@ -15,7 +15,7 @@ import java.time.YearMonth
 
 @Composable
 fun rememberMonthlyScreenState(
-    year: Int, month: Int,
+    yearMonth: YearMonth,
     monthlyViewModel: MonthlyViewModel,
     toolbarMinHeight: Dp = 60.dp,
     toolbarMaxHeight: Dp = 150.dp,
@@ -32,9 +32,9 @@ fun rememberMonthlyScreenState(
         derivedStateOf { posts.value.associateBy { it.date } }
     }
 
-    return remember(year, month) {
+    return remember(yearMonth) {
         MonthlyScreenStateHolder(
-            date = YearMonth.of(year, month),
+            date = yearMonth,
             posts = groupedPost,
             toolbarState = toolbarState,
             lazyListState = lazyListState,

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyUiState.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyUiState.kt
@@ -15,7 +15,6 @@ import java.time.YearMonth
 
 @Composable
 fun rememberMonthlyScreenState(
-    yearMonth: YearMonth,
     monthlyViewModel: MonthlyViewModel,
     toolbarMinHeight: Dp = 60.dp,
     toolbarMaxHeight: Dp = 150.dp,
@@ -32,9 +31,9 @@ fun rememberMonthlyScreenState(
         derivedStateOf { posts.value.associateBy { it.date } }
     }
 
-    return remember(yearMonth) {
+    return remember(monthlyViewModel) {
         MonthlyScreenStateHolder(
-            date = yearMonth,
+            date = monthlyViewModel.date.currentYearMonth,
             posts = groupedPost,
             toolbarState = toolbarState,
             lazyListState = lazyListState,

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
@@ -1,5 +1,6 @@
 package com.feature.monthly
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.core.domain.post.GetPostByMonthUseCase
@@ -11,23 +12,29 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.time.YearMonth
 import javax.inject.Inject
 
 @HiltViewModel
 class MonthlyViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val getPostByMonthUseCase: GetPostByMonthUseCase,
     private val removePostUseCase: RemovePostUseCase
 ) : ViewModel() {
 
-    private val _posts = MutableStateFlow<List<PostUiModel>>(emptyList())
-    val posts: StateFlow<List<PostUiModel>> = _posts.asStateFlow()
+    internal val date = YearMonthArg(savedStateHandle)
 
-    fun init(year: Int, month: Int) {
+    init {
         viewModelScope.launch {
-            _posts.value = getPostByMonthUseCase(year, month).map { it.toPostUiModel() }
-            println(_posts.value)
+            _posts.value = getPostByMonthUseCase(
+                date.currentYearMonth.year,
+                date.currentYearMonth.monthValue
+            ).map { it.toPostUiModel() }
         }
     }
+
+    private val _posts = MutableStateFlow<List<PostUiModel>>(emptyList())
+    val posts: StateFlow<List<PostUiModel>> = _posts.asStateFlow()
 
     fun removePost(postUiModel: PostUiModel) {
         viewModelScope.launch {

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
@@ -24,7 +24,10 @@ class MonthlyViewModel @Inject constructor(
 
     internal val date = YearMonthArg(savedStateHandle)
 
-    init {
+    private val _posts = MutableStateFlow<List<PostUiModel>>(emptyList())
+    val posts: StateFlow<List<PostUiModel>> = _posts.asStateFlow()
+
+    fun getPost() {
         viewModelScope.launch {
             val result = getPostByMonthUseCase(
                 date.currentYearMonth.year,
@@ -33,9 +36,6 @@ class MonthlyViewModel @Inject constructor(
             _posts.value = result
         }
     }
-
-    private val _posts = MutableStateFlow<List<PostUiModel>>(emptyList())
-    val posts: StateFlow<List<PostUiModel>> = _posts.asStateFlow()
 
     fun removePost(postUiModel: PostUiModel) {
         viewModelScope.launch {

--- a/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/MonthlyViewModel.kt
@@ -26,10 +26,11 @@ class MonthlyViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            _posts.value = getPostByMonthUseCase(
+            val result = getPostByMonthUseCase(
                 date.currentYearMonth.year,
                 date.currentYearMonth.monthValue
             ).map { it.toPostUiModel() }
+            _posts.value = result
         }
     }
 

--- a/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyBody.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyBody.kt
@@ -26,7 +26,8 @@ fun MonthlyBody(
     date: YearMonth,
     dateCount: Int,
     onChangeListType: () -> Unit,
-    onRemovePost: (PostUiModel) -> Unit
+    onRemovePost: (PostUiModel) -> Unit,
+    onClickPost: (LocalDate) -> Unit
 ) {
     HarooSurface(
         modifier = Modifier.fillMaxWidth(),
@@ -53,7 +54,8 @@ fun MonthlyBody(
                         date = day,
                         post = groupedPosts[day],
                         postItemType = if (listType) PostItemType.GRID else PostItemType.LINEAR,
-                        onRemovePost = onRemovePost
+                        onRemovePost = onRemovePost,
+                        onClickPost = onClickPost
                     )
                 }
             }
@@ -68,7 +70,8 @@ fun MonthlyPostItem(
     date: LocalDate,
     post: PostUiModel?,
     postItemType: PostItemType,
-    onRemovePost: (PostUiModel) -> Unit
+    onRemovePost: (PostUiModel) -> Unit,
+    onClickPost: (LocalDate) -> Unit
 ) {
     PostItemByType(
         date = date,
@@ -76,6 +79,7 @@ fun MonthlyPostItem(
         isLastItem = isLastItem,
         post = post,
         postItemType = postItemType,
-        onRemovePost = onRemovePost
+        onRemovePost = onRemovePost,
+        onClickPost = onClickPost
     )
 }

--- a/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyHeader.kt
+++ b/feature/monthly/src/main/java/com/feature/monthly/ui/MonthlyHeader.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import com.core.designsystem.components.HarooVerticalDivider
 import com.core.designsystem.components.calendar.Calendar
+import com.core.designsystem.modifiers.noRippleClickable
 import com.core.designsystem.util.getString
 import com.core.model.feature.PostUiModel
 import com.core.ui.date.DateWithImage
@@ -27,6 +28,7 @@ fun MonthlyHeader(
     modifier: Modifier = Modifier,
     posts: Map<LocalDate, PostUiModel>,
     date: YearMonth,
+    toPostScreen: (LocalDate) -> Unit,
     progressProvider: () -> Float
 ) {
     Layout(
@@ -35,6 +37,7 @@ fun MonthlyHeader(
             MonthlyHeaderContent(
                 date = date,
                 posts = posts,
+                toPostScreen = toPostScreen,
                 progressProvider = progressProvider
             )
         }
@@ -69,6 +72,7 @@ fun MonthlyHeaderContent(
     date: YearMonth,
     posts: Map<LocalDate, PostUiModel>,
     monthAndNamePadding: Dp = Dimens.monthAndNameDefaultPadding,
+    toPostScreen: (LocalDate) -> Unit,
     progressProvider: () -> Float
 ) {
     RowMonthAndName(
@@ -81,6 +85,7 @@ fun MonthlyHeaderContent(
         modifier = Modifier.layoutId("Calendar"),
         posts = posts,
         date = date,
+        onClickPost = toPostScreen,
         progressProvider = progressProvider
     )
     MonthlyInfosContainer(
@@ -98,6 +103,7 @@ fun MonthlyCalendar(
     date: YearMonth,
     verticalSpace: Dp = Dimens.monthlyCalendarVerticalSpace,
     horizontalSpace: Dp = Dimens.monthlyCalendarHorizontalSpace,
+    onClickPost: (LocalDate) -> Unit,
     progressProvider: () -> Float
 ) {
     Calendar(
@@ -112,7 +118,9 @@ fun MonthlyCalendar(
             },
         dayContent = {
             DateWithImage(
-                modifier = Modifier.padding(horizontal = horizontalSpace),
+                modifier = Modifier
+                    .padding(horizontal = horizontalSpace)
+                    .noRippleClickable { onClickPost(it.date) },
                 state = it,
                 image = posts[it.date]?.images?.firstOrNull()
             )

--- a/feature/post/src/main/java/com/feature/post/PostNavigation.kt
+++ b/feature/post/src/main/java/com/feature/post/PostNavigation.kt
@@ -40,7 +40,7 @@ fun NavGraphBuilder.postScreen(
     onBackPressed: () -> Unit
 ) {
     composable(
-        route = "$POST_SCREEN_ROUTE/$YEAR_ARG/$MONTH_ARG/${DAY_ARG}",
+        route = "$POST_SCREEN_ROUTE/{$YEAR_ARG}/{$MONTH_ARG}/{${DAY_ARG}}",
         arguments = listOf(
             navArgument(YEAR_ARG) { type = NavType.IntType },
             navArgument(MONTH_ARG) { type = NavType.IntType },

--- a/feature/post/src/main/java/com/feature/post/PostNavigation.kt
+++ b/feature/post/src/main/java/com/feature/post/PostNavigation.kt
@@ -1,0 +1,52 @@
+package com.feature.post
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import java.time.LocalDate
+
+private const val YEAR_ARG = "year"
+private const val MONTH_ARG = "month"
+private const val DAY_ARG = "day"
+private const val POST_SCREEN_ROUTE = "post"
+
+internal class DateArg(savedStateHandle: SavedStateHandle) {
+    var currentDate: LocalDate
+    val year: Int get() = currentDate.year
+    val month: Int get() = currentDate.monthValue
+    val day: Int get() = currentDate.dayOfMonth
+
+    init {
+        val year: Int? = savedStateHandle[YEAR_ARG]
+        val month: Int? = savedStateHandle[MONTH_ARG]
+        val day: Int? = savedStateHandle[DAY_ARG]
+        currentDate =
+            if (year == null || month == null || day == null) LocalDate.now()
+            else LocalDate.of(year, month, day)
+    }
+}
+
+fun NavController.navigateToPost(date: LocalDate) {
+    val year = date.year
+    val month = date.monthValue
+    val day = date.dayOfMonth
+    this.navigate("$POST_SCREEN_ROUTE/$year/$month/$day")
+}
+
+fun NavGraphBuilder.postScreen(
+    onBackPressed: () -> Unit
+) {
+    composable(
+        route = "$POST_SCREEN_ROUTE/$YEAR_ARG/$MONTH_ARG/${DAY_ARG}",
+        arguments = listOf(
+            navArgument(YEAR_ARG) { type = NavType.IntType },
+            navArgument(MONTH_ARG) { type = NavType.IntType },
+            navArgument(DAY_ARG) { type = NavType.IntType }
+        )
+    ) {
+        PostRoute(onBackPressed)
+    }
+}

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -72,11 +72,6 @@ fun PostScreen(
     postStateHolder.CollectPressFlag()
 
     HarooBottomDrawer(
-        modifier = Modifier
-            .statusBarsPadding()
-            .navigationBarsPadding()
-            .imePadding()
-            .background(Brush.linearGradient(HarooTheme.colors.interactiveBackground)),
         drawerState = postStateHolder.bottomDrawerState,
         drawerContent = {
             DrawerGalleryContainer(

--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -36,17 +36,19 @@ import com.feature.post.ui.Dimens
 import java.time.LocalDate
 
 @Composable
-fun PostScreen(
-    year: Int, month: Int, day: Int,
+fun PostRoute(
+    onBackPressed: () -> Unit,
     postViewModel: PostViewModel = hiltViewModel()
 ) {
-    val postStateHolder =
-        rememberPostScreenState(year, month, day, postViewModel = postViewModel, onBackPressed = {})
+    val postStateHolder = rememberPostScreenState(
+        postViewModel = postViewModel,
+        onBackPressed = onBackPressed
+    )
 
     LaunchedEffect(Unit) {
         postViewModel.postUiEvent.collect {
             when (it) {
-                PostUiEvent.Initialized -> postViewModel.getPost(year, month, day)
+                PostUiEvent.Initialized -> {}
                 PostUiEvent.EndLoadInitDate -> {}
                 PostUiEvent.FailSaveOrEditPost -> {}
                 PostUiEvent.SuccessSaveOrEditPost -> {}

--- a/feature/post/src/main/java/com/feature/post/PostUiState.kt
+++ b/feature/post/src/main/java/com/feature/post/PostUiState.kt
@@ -18,7 +18,6 @@ import java.time.LocalDate
 
 @Composable
 fun rememberPostScreenState(
-    year: Int, month: Int, day: Int,
     postViewModel: PostViewModel,
     bottomDrawerState: HarooBottomDrawerState = rememberHarooBottomDrawerState(),
     focusManager: FocusManager = LocalFocusManager.current,
@@ -34,9 +33,9 @@ fun rememberPostScreenState(
     val postId = postViewModel.postId.collectAsState()
     val isEditMode = postViewModel.isEditMode.collectAsState()
 
-    return remember(year, month, day, postViewModel, bottomDrawerState) {
+    return remember(postViewModel, bottomDrawerState) {
         PostScreenStateHolder(
-            year, month, day,
+            date = postViewModel.date.currentDate,
             postViewModel = postViewModel,
             images = images,
             _selectedImages = selectedImages,
@@ -55,9 +54,7 @@ fun rememberPostScreenState(
 }
 
 class PostScreenStateHolder(
-    private val year: Int,
-    private val month: Int,
-    private val day: Int,
+    val date: LocalDate,
     private val postViewModel: PostViewModel,
     val images: LazyPagingItems<ImageUiModel>,
     private val _selectedImages: State<List<ImageUiModel>>,
@@ -80,8 +77,6 @@ class PostScreenStateHolder(
         get() = _content.value
     val showTagTextFieldFlag: Boolean
         get() = _showTagTextFieldFlag.value
-    val date: LocalDate
-        get() = LocalDate.of(year, month, day)
 
     val isBottomDrawer: State<Boolean>
         get() = bottomDrawerState.isShow
@@ -174,7 +169,7 @@ class PostScreenStateHolder(
         when (postType) {
             PostType.SHOW -> postViewModel.toggleEditMode()
             PostType.NEW,
-            PostType.EDIT -> postViewModel.savePost(year, month, day)
+            PostType.EDIT -> postViewModel.savePost()
         }
     }
 
@@ -184,7 +179,7 @@ class PostScreenStateHolder(
     fun onBackPressed() {
         when (postType) {
             PostType.EDIT -> {
-                postViewModel.getPost(year, month, day)
+                postViewModel.getPost()
                 postViewModel.toggleEditMode()
             }
             PostType.NEW,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ activityCompose = '1.6.1'
 coil = '2.2.2'
 composeUi = '1.4.0'
 compose-kotlin-compiler = '1.4.0'
+compose-navigation = '2.5.3'
 coroutine = '1.6.4'
 espresso = '3.5.1'
 hamcrest = "1.1"
@@ -37,6 +38,7 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 androidx-activitiy-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle-runtime-compose" }
 androidx-compose-ui-util = { group = "androidx.compose.ui", name = "ui-util", version.ref = "composeUi" }
+androidx-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "compose-navigation" }
 androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "composeUi" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation", version.ref = "composeUi" }
 androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "composeUi" }
@@ -88,6 +90,7 @@ compose = [
     'androidx-activitiy-compose',
     'androidx-lifecycle-runtime-compose',
     'hilt-navigation-compose',
+    'androidx-compose-navigation',
     'androidx-compose-ui-util',
     'androidx-compose-material',
     'androidx-compose-animation',


### PR DESCRIPTION
#### 📌 내용
MainActivity에서 Navigation 관리 및 AppState로 전체 State 관리

#### 🛠 Done
- [x] Navigation에 필요한 class 추가
- [x] HomeScreen Navigation 정보
- [x] MonthlyScreen Navigation 정보
- [x] PostScreen Navigation 정보
- [x] HomeScreen Navigation 추가
- [x] MonthlyScreen Navigation 추가
- [x] PostScreen Navigation 추가
- [x] HomeScreen에서 MonthlyScreen으로 이동
- [x] HomeScreen에서 PostScreen으로 이동
- [x] MonthlyScreen에서 PostScreen으로 이동
- [x] MonthlyScreen에서 HomeScreen으로 Back
- [x] PostScreen에서 이전 화면으로 Back

#### 🏠 관련 Issue
Closed #38 