### PR TITLE
[FIX] #43 가끔 Post의 이미지를 불러오지 못하는 이슈 수정

### DIFF
--- a/feature/post/src/main/java/com/feature/post/PostScreen.kt
+++ b/feature/post/src/main/java/com/feature/post/PostScreen.kt
@@ -88,6 +88,10 @@ fun PostScreen(
     BackHandler(enabled = postStateHolder.isBottomDrawer.value) {
         postStateHolder.bottomDrawerHide()
     }
+    // BottomDrawer 가 닫혀 있다면
+    BackHandler(enabled = postStateHolder.isBottomDrawer.value.not()) {
+        postStateHolder.onBackPressed()
+    }
 
     postStateHolder.CollectImeVisible()
     postStateHolder.CollectPressFlag()

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -46,19 +46,27 @@ class PostViewModel @Inject constructor(
     private val _isEditMode = MutableStateFlow(false)
     val isEditMode: StateFlow<Boolean> = _isEditMode.asStateFlow()
 
+    // 갤러리 이미지
     val images = getImagesUseCase()
         .map { images ->
             images.map { it.toImageUiModel() }
         }.cachedIn(viewModelScope)
 
+    // 선택한 이미지
     private val _selectedImages = MutableStateFlow<List<ImageUiModel>>(emptyList())
     val selectedImages: StateFlow<List<ImageUiModel>> = _selectedImages.asStateFlow()
+
+    // 기존 이미지 중, 제거한 이미지
     private val removeImages = mutableListOf<ImageUiModel>()
 
+    // 추가한 태그
     private val _tags = MutableStateFlow<List<TagUiModel>>(emptyList())
     val tags: StateFlow<List<TagUiModel>> = _tags.asStateFlow()
+
+    // 기존 태그 중, 제거한 태그
     private val removeTags = mutableListOf<TagUiModel>()
 
+    // 내용
     private val _content = MutableStateFlow("")
     val content: StateFlow<String> = _content.asStateFlow()
 
@@ -69,20 +77,12 @@ class PostViewModel @Inject constructor(
         viewModelScope.launch {
             getPostByDateUseCase(
                 date.year, date.month, date.day
-            ).onSuccess {
-                it?.let { post ->
-                    _content.value = post.content ?: ""
-                    _selectedImages.value = post.images.map { it.toImageUiModel() }
-                    _tags.value = post.tags.map { it.toTagUiModel() }
-
-                    _postId.value = post.id ?: -1
-                } ?: kotlin.run {
-                    _content.value = ""
-                    _selectedImages.value = emptyList()
-                    _tags.value = emptyList()
-                    _postId.value = null
-                    _isEditMode.value = true
-                }
+            ).onSuccess { post ->
+                _content.value = post?.content ?: ""
+                _selectedImages.value = post?.images?.map { it.toImageUiModel() } ?: emptyList()
+                _tags.value = post?.tags?.map { it.toTagUiModel() } ?: emptyList()
+                _postId.value = post?.id
+                _isEditMode.value = post == null
             }.onFailure {
                 _postUiEvent.emit(PostUiEvent.Fail.GetPost)
             }

--- a/feature/post/src/main/java/com/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/feature/post/PostViewModel.kt
@@ -82,11 +82,17 @@ class PostViewModel @Inject constructor(
                 _selectedImages.value = post?.images?.map { it.toImageUiModel() } ?: emptyList()
                 _tags.value = post?.tags?.map { it.toTagUiModel() } ?: emptyList()
                 _postId.value = post?.id
-                _isEditMode.value = post == null
+                toShowOrEditMode()
             }.onFailure {
                 _postUiEvent.emit(PostUiEvent.Fail.GetPost)
             }
         }
+    }
+
+    private fun toShowOrEditMode() {
+        _isEditMode.value = _postId.value == null
+        removeImages.clear()
+        removeTags.clear()
     }
 
     /**
@@ -117,7 +123,7 @@ class PostViewModel @Inject constructor(
                 removeTags = removeTags.map { it.toTag() }
             ).onSuccess {
                 _postId.value = it
-                _isEditMode.value = false
+                toShowOrEditMode()
                 _postUiEvent.emit(PostUiEvent.Success.SavePost)
             }.onFailure {
                 _postUiEvent.emit(PostUiEvent.Fail.SavePost)


### PR DESCRIPTION
#### 📌 내용
가끔 Post 정보는 받아왔지만 이미지가 보이지 않는 이슈를 확인하였습니다. 수정 부탁드립니다.

#### 🏠 원인분석
PostViewModel에서 Post 저장 이후, removaImages 리스트를 초기화해주지 않아 이후 다시 게시글을 수정하려고 할 때 기존 removaImage에 이미지들이 삭제되는 것이 원인이었습니다.

#### 🪴 수정
PostViewModel에서 Post EditMode 취소 또는 저장 후, removeImage와 removeTag 배열을 clear해주었습니다.

#### 🛠 추가 수정사항
- [x] PostScreen에서 수정모드이면서 시스템 BackButton을 클릭하면, show mode로 변경
- [x] PostViewModel.getPost 코드 정리

#### 🌹 관견 Issue
Closed #44 