### PR TITLE
[REFACTOR] #39 Home Paging Refresh 위치 지정

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/core/data/src/main/java/com/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/core/data/di/RepositoryModule.kt
@@ -8,6 +8,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -18,6 +19,7 @@ interface RepositoryModule {
     ): ImageRepository
 
     @Binds
+    @Singleton
     fun bindPostRepository(
         postLocalRepositoryImpl: PostLocalRepositoryImpl
     ): PostRepository

--- a/core/data/src/main/java/com/core/data/post/PostRepository.kt
+++ b/core/data/src/main/java/com/core/data/post/PostRepository.kt
@@ -25,7 +25,7 @@ interface PostRepository {
     suspend fun getPosts(year: Int, month: Int): Result<List<PostSource>>
 
     // 특정 년도/월 post paging 요청
-    fun getPostPaging(): Flow<PagingData<PostSources>>
+    fun getPostPaging(pageSize: Int): Flow<PagingData<PostSources>>
 
     // 특정 날짜의 게시글 제거
     suspend fun removePost(postId: Long): Result<Unit>

--- a/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
+++ b/core/data/src/main/java/com/core/data/post/local/PostLocalRepositoryImpl.kt
@@ -119,13 +119,16 @@ class PostLocalRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getPostPaging(): Flow<PagingData<PostSources>> {
+    override fun getPostPaging(pageSize: Int): Flow<PagingData<PostSources>> {
         return Pager(
             config = PagingConfig(
-                pageSize = PostLocalPagingSource.PAGING_SIZE
+                pageSize = pageSize
             ),
             pagingSourceFactory = {
-                val source = PostLocalPagingSource(ioDispatcher, postDao)
+                val source = PostLocalPagingSource(
+                    ioDispatcher, postDao,
+                    pageSize
+                )
                 pagingInvalidate = { source.invalidate() }
                 source
             }

--- a/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonthUseCase.kt
+++ b/core/domain/src/main/java/com/core/domain/post/GetPostPageByMonthUseCase.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class GetPostPageByMonthUseCase @Inject constructor(
     private val postRepository: PostRepository
 ) {
-    operator fun invoke(): Flow<PagingData<Posts>> {
-        return postRepository.getPostPaging().map { it.map { post -> post.toPosts() } }
+    operator fun invoke(pageSize: Int): Flow<PagingData<Posts>> {
+        return postRepository.getPostPaging(pageSize).map { it.map { post -> post.toPosts() } }
     }
 }

--- a/core/model/src/main/java/com/core/model/data/ImageSource.kt
+++ b/core/model/src/main/java/com/core/model/data/ImageSource.kt
@@ -7,7 +7,7 @@ import com.core.model.datastore.ImageData
  * datasource Image 정보
  */
 data class ImageSource(
-    val id: Long?, // 이미지 id
+    val id: Long, // 이미지 id
     val imageUrl: String // 이지미 url
 )
 

--- a/core/model/src/main/java/com/core/model/database/ImageEntity.kt
+++ b/core/model/src/main/java/com/core/model/database/ImageEntity.kt
@@ -4,7 +4,6 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.ForeignKey.CASCADE
-import androidx.room.PrimaryKey
 
 /**
  * Image Table
@@ -18,11 +17,12 @@ import androidx.room.PrimaryKey
             childColumns = ["post_id"],
             onDelete = CASCADE
         )
-    ]
+    ],
+    primaryKeys = ["image_id","post_id"]
 )
 data class ImageEntity(
-    @PrimaryKey(autoGenerate = true)
-    val id: Long?,
+    @ColumnInfo(name = "image_id", index = true)
+    val id: Long,
     @ColumnInfo(name = "post_id", index = true)
     val postId: Long,
     @ColumnInfo(name = "image_url")

--- a/core/model/src/main/java/com/core/model/domain/Image.kt
+++ b/core/model/src/main/java/com/core/model/domain/Image.kt
@@ -3,7 +3,7 @@ package com.core.model.domain
 import com.core.model.data.ImageSource
 
 data class Image(
-    val id: Long?,
+    val id: Long,
     val imageUrl: String
 )
 

--- a/core/model/src/main/java/com/core/model/feature/ImageUiModel.kt
+++ b/core/model/src/main/java/com/core/model/feature/ImageUiModel.kt
@@ -3,7 +3,7 @@ package com.core.model.feature
 import com.core.model.domain.Image
 
 data class ImageUiModel(
-    override val id: Long?,
+    override val id: Long,
     val imageUrl: String
 ) : Model(id, CellType.IMAGE)
 

--- a/feature/home/src/main/java/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeScreen.kt
@@ -68,7 +68,7 @@ fun HomeRoute(
     LaunchedEffect(key1 = isItem.value) {
         if (isItem.value && homeViewModel.recentVisibleItemOffset != null) {
             val index = postPagingItems.itemSnapshotList.indexOfFirst { it?.date == homeViewModel.recentVisibleItem }
-            if (index >= 0) scrollState.animateScrollToItem(
+            if (index >= 0) scrollState.scrollToItem(
                 index = index,
                 scrollOffset = homeViewModel.recentVisibleItemOffset!!
             )

--- a/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
@@ -25,7 +25,8 @@ class HomeViewModel @Inject constructor(
     private val _homeUiEvent = MutableSharedFlow<HomeUiEvent>()
     val homeUiEvent: SharedFlow<HomeUiEvent> = _homeUiEvent.asSharedFlow()
 
-    val posts = getPostPageByMonthUseCase().map { it.map { post -> post.toPostsUiModel() } }
+    val posts = getPostPageByMonthUseCase()
+        .map { it.map { post -> post.toPostsUiModel() } }
         .cachedIn(viewModelScope)
 
     fun removePost(postUiModel: PostUiModel) {

--- a/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/feature/home/HomeViewModel.kt
@@ -14,7 +14,9 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.launch
+import java.time.YearMonth
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,7 +27,7 @@ class HomeViewModel @Inject constructor(
     private val _homeUiEvent = MutableSharedFlow<HomeUiEvent>()
     val homeUiEvent: SharedFlow<HomeUiEvent> = _homeUiEvent.asSharedFlow()
 
-    val posts = getPostPageByMonthUseCase()
+    val posts = getPostPageByMonthUseCase(PAGE_SIZE)
         .map { it.map { post -> post.toPostsUiModel() } }
         .cachedIn(viewModelScope)
 
@@ -37,6 +39,13 @@ class HomeViewModel @Inject constructor(
                     .onFailure { _homeUiEvent.emit(HomeUiEvent.Fail.RemovePost) }
             }
         }
+    }
+
+    var recentVisibleItem = YearMonth.now()
+    var recentVisibleItemOffset: Int? = null
+
+    companion object {
+        const val PAGE_SIZE = 10
     }
 }
 


### PR DESCRIPTION
#### 📌 내용
HomeScreen에서 Paging Refresh 시, 현재 List 위치를 유지할 수 있도록 수정 필요

#### 🛠 Done
- [x] Post 삭제 시
- [x] Post 변경 후, Back stack 시

#### 🔥 파악한 원인
Paging Refresh 이후에 pagingListItem의 순서가 변경되었는데도 ScrollState가 유지되어 있어, 다른 Item에 focusing 되어 있던 것이 원인이었습니다.

#### 🪴 해결방법
HomeScreen에서 dispose 시, 현재 보이는 첫 Item의 YearMonth와 Offset을 저장해둔 이후에, 다시 HomeScreen으로 돌아왔을 떄 해당 YearMonth와 Offset으로 이동하도록 scrollToIem 사용

#### 🏠 관련 Issue
Closed #39 